### PR TITLE
Fix typo comma showing up in the nav

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -119,7 +119,6 @@ function App() {
           </Snackbar>
         )}
       </QueryClientProvider>
-      ,
     </div>
   )
 }


### PR DESCRIPTION
I set up donetick locally and noticed that there's some strange character on the main view:
<img width="233" alt="image" src="https://github.com/user-attachments/assets/2ae0b440-e63d-47dd-aacc-74f5cc102036" />

Investigating shows it's a typo in the JSX which was probably inadvertently introduced by [this commit](https://github.com/dkhalife/donetick-frontend/commit/42182371ffba7f76c1b88e261ea4df4b60f1ed93)