### PR TITLE
Bugfix: handle request error when updating notification type

### DIFF
--- a/src/views/Settings/NotificationSetting.jsx
+++ b/src/views/Settings/NotificationSetting.jsx
@@ -45,7 +45,11 @@ const NotificationSetting = () => {
       target: chatID,
       type: Number(notificationTarget),
     }).then(resp => {
-      alert('Notification target updated')
+      if (resp.status != 200) {
+        alert(`Error while updating notification target: ${resp.statusText}`)
+        return
+      }
+
       setUserProfile({
         ...userProfile,
         notification_target: {
@@ -53,6 +57,7 @@ const NotificationSetting = () => {
           type: Number(notificationTarget),
         },
       })
+      alert('Notification target updated')
     })
   }
   return (


### PR DESCRIPTION
This is related to [this pr](https://github.com/donetick/donetick/pull/58). Basically, if there is a failure on the service, the frontend currently does not tell the user and instead shows a successful message.
Added error handling to show any error from the service and moved the successful message to be last, just in case something else happened.