### PR TITLE
Add setting for mqtt notification

### DIFF
--- a/src/views/Settings/NotificationSetting.jsx
+++ b/src/views/Settings/NotificationSetting.jsx
@@ -386,6 +386,7 @@ const NotificationSetting = () => {
             <Option value='0'>None</Option>
             <Option value='1'>Telegram</Option>
             <Option value='2'>Pushover</Option>
+            <Option value='2'>Mqtt</Option>
           </Select>
           {notificationTarget === '1' && (
             <>


### PR DESCRIPTION
When selected, this setting will enable notifications to flow through an Mqtt connection defined in the backend repo

See https://github.com/donetick/donetick/pull/78 for backend implementation