### PR TITLE
Added a scroll bar to the chore creation page when Due date is selected to stop labels text from getting cut off

### DIFF
--- a/src/views/ChoreEdit/ChoreEdit.jsx
+++ b/src/views/ChoreEdit/ChoreEdit.jsx
@@ -330,7 +330,7 @@ const ChoreEdit = () => {
     })
   }
   return (
-    <Container maxWidth='md'>
+    <Container maxWidth='md' className='overflow-auto'>
       {/* <Typography level='h3' mb={1.5}>
         Edit Chore
       </Typography> */}


### PR DESCRIPTION
The text at the bottom as well as the labels drop down would get cut off and no scroll bar would appear before
![image](https://github.com/user-attachments/assets/d2367f32-37ea-4307-bca9-623e6184a4f3)


Now scrollbar appears when due date's "Give this task a due date" option is selected
![image](https://github.com/user-attachments/assets/15aa4559-04bd-4485-b5af-70091b1a40d6)
