### PR TITLE
Fixed & adjusted a range of casing/wording on the homepage

### DIFF
--- a/src/views/Landing/DemoHistory.jsx
+++ b/src/views/Landing/DemoHistory.jsx
@@ -78,7 +78,7 @@ const DemoHistory = () => {
           data-aos='fade-left'
         >
           <Typography level='h3' textAlign='center' sx={{ mt: 2, mb: 4 }}>
-            History with a purpose
+            History with a Purpose
           </Typography>
           <Typography level='body-lg' textAlign='center' sx={{ mb: 4 }}>
             Keep track of all your chores and tasks with ease. Donetick records

--- a/src/views/Landing/DemoMyChore.jsx
+++ b/src/views/Landing/DemoMyChore.jsx
@@ -119,7 +119,7 @@ const DemoMyChore = () => {
           data-aos='fade-left'
         >
           <Typography level='h3' textAlign='center' sx={{ mt: 2, mb: 4 }}>
-            Glance at your task and chores
+            Glance at Your Task and Chores
           </Typography>
           <Typography level='body-lg' textAlign='center' sx={{ mb: 4 }}>
             Main view prioritize tasks due today, followed by overdue ones, and

--- a/src/views/Landing/FeaturesSection.jsx
+++ b/src/views/Landing/FeaturesSection.jsx
@@ -33,31 +33,31 @@ const CardData = [
   {
     title: 'Circles: Your Task Hub',
     description:
-      'build with sharing in mind. invite other to the circle and you can assign tasks to each other. and only see the tasks the should be shared',
+      'Built with sharing in mind. Invite others a circle so you can assign tasks to each other, only seeing the tasks the should be shared.',
     icon: GroupRounded,
   },
   {
     title: 'Track Your Progress',
     description:
-      'View a history of completed tasks. or use things to track simply things!',
+      "See a full history of completed tasks so you can keep track of what's been achieved!",
     icon: HistoryRounded,
   },
   {
     title: 'Automated Task Scheduling',
     description:
-      'Set up Tasks to repeat daily, weekly, or monthly, or maybe specifc day in specifc months? Donetick have a flexible scheduling system',
+      'Set up tasks to repeat daily, weekly, monthly, or even specific days in specific months? Donetick has a flexible scheduling system.',
     icon: AutoAwesomeMosaicOutlined,
   },
   {
     title: 'Automated Task Assignment',
     description:
-      'For shared tasks, Donetick can randomly rotate assignments or choose based on last completion or least assigned.',
+      'For shared tasks Donetick can randomly rotate assignments, or choose based on last completion or least assigned.',
     icon: AutoAwesomeRounded,
   },
   {
     title: 'Integrations & Webhooks',
     description:
-      'Donetick can update things programmatically with API call. you can update things from other services like IFTTT, Homeassistant or even your own service',
+      'Donetick can update things programmatically with API calls. It can integrate with IFTTT, Home Assistant or even your own services.',
     icon: Webhook,
   },
 ]

--- a/src/views/Landing/GettingStarted.jsx
+++ b/src/views/Landing/GettingStarted.jsx
@@ -72,7 +72,7 @@ const GettingStarted = () => {
       title: 'Donetick Web',
       icon: <Cloud style={{ fontSize: '48px' }} />,
       description:
-        'The easiest way! just create account and start using DoneTick',
+        'The easiest way! Just create account and start using Donetick',
       button: (
         <Button
           size='lg'
@@ -89,7 +89,7 @@ const GettingStarted = () => {
     {
       title: 'Selfhosted',
       icon: <Storage style={{ fontSize: '48px' }} />,
-      description: 'Download the binary and manage your own DoneTick instance',
+      description: 'Download the binary and manage your own Donetick instance',
       button: (
         <Button
           size='lg'
@@ -110,7 +110,7 @@ const GettingStarted = () => {
       title: 'Hassio Addon',
       icon: <AddHome style={{ fontSize: '48px' }} />,
       description:
-        'have Home Assistant? install DoneTick as a Home Assistant Addon with single click',
+        'Have Home Assistant? Install Donetick as a Home Assistant Addon with single click',
       button: (
         <Button
           size='lg'
@@ -143,11 +143,11 @@ const GettingStarted = () => {
 
       <Box maxWidth={'lg'} sx={{ mb: 8 }}>
         <Typography level='body-md' color='neutral'>
-          you can start using DoneTick in multiple ways, easiest way is to use
-          Donetick Web and you can start in seconds, or if you are into
-          selfhosting you can download the binary and run it on your own server,
-          or if you are using Home Assistant you can install DoneTick as a Home
-          Assistant Addon
+          You can start using Donetick in multiple ways, the easiest of which is
+          to use Donetick Web so you can get started in seconds, or if you are
+          into selfhosting you can download the binary and run it on your own
+          server, or if you are using Home Assistant you can install Donetick as
+          a Home Assistant Addon
         </Typography>
         <div data-aos-id-getting-started-container>
           <Grid container spacing={4} mt={4}>


### PR DESCRIPTION
This PR makes a range of grammatical adjustments to the text seen on the homepage:

- Aligns casing of "Donetick".
- Fixes and aligns casing of titles and paragraphs.
- Makes use of full-stops/line-endings consistent across similar paragraphs.
- Fixes some wording and sentence structure.

---

No pressure to take on all (or any) of these changes if you don't want. Just putting forward changes for things that looked odd to me when visiting the page.

---

As an aside, i noticed the following in your readme:

> This project is licensed under the AGPLv3 License. See the [LICENSE](https://github.com/donetick/frontend/blob/main/LICENSE) file for more details. I might consider changing it later to something else

This is something you might want to consider sooner rather than later due to how the AGPLv3 works.
If you need to re-license down the road, you'd need to gain the permission of those who have contributed under AGPLv3, or otherwise replace those contributions. 
Often projects with potential license change plans will get permission up-front from contributions before any contributions are merged in (often via a CLA). 
Personally I'm not a big fan of AGPLv3 projects with a CLA, but since you've shown intent to change it's best to understand and plan for this early rather than untangle things later down the road.