### PR TITLE
Allow HTTP (non secure) requests in Android app

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -6,7 +6,8 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/AppTheme">
+        android:theme="@style/AppTheme"
+        android:usesCleartextTraffic="true">
         <activity
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|smallestScreenSize|screenLayout|uiMode"
             android:name=".MainActivity"

--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -4,7 +4,9 @@ const config: CapacitorConfig = {
   appId: 'com.donetick.app',
   appName: 'Donetick',
   webDir: 'dist',
-  
+  android: {
+    allowMixedContent: true,
+  },
   plugins: {
     PushNotifications: {
       presentationOptions: ['badge', 'sound', 'alert'],


### PR DESCRIPTION
I was trying out Donetick, really cool app btw! 🙌
While setting up a self-hosted instance, I noticed that I couldn't connect to it using the Android app.
After looking further into it, I saw that `http://` requests were being blocked, while `https://` worked fine.

This PR makes it so that http requests are allowed.