### PR TITLE
fix: UI strings - use consistent spacing/capitalization

### DIFF
--- a/src/views/ChoreEdit/ChoreEdit.jsx
+++ b/src/views/ChoreEdit/ChoreEdit.jsx
@@ -856,7 +856,7 @@ const ChoreEdit = () => {
                 label='Give this task a due date'
               />
               <FormHelperText>
-                task needs to be completed by a specific time.
+                Task needs to be completed by a specific time
               </FormHelperText>
             </FormControl>
           )}

--- a/src/views/ChoreEdit/RepeatSection.jsx
+++ b/src/views/ChoreEdit/RepeatSection.jsx
@@ -542,7 +542,7 @@ const RepeatSection = ({
 
   return (
     <Box mt={2}>
-      <Typography level='h4'>Repeat :</Typography>
+      <Typography level='h4'>Repeat:</Typography>
       <FormControl sx={{ mt: 1 }}>
         <Checkbox
           onChange={e => {

--- a/src/views/Landing/DemoAssignee.jsx
+++ b/src/views/Landing/DemoAssignee.jsx
@@ -52,7 +52,7 @@ const DemoAssignee = () => {
           data-aos-anchor='[data-aos-create-chore-assignee]'
           data-aos='fade-right'
         >
-          <Typography level='h4'>Assignees :</Typography>
+          <Typography level='h4'>Assignees:</Typography>
           <Typography level='h5'>Who can do this chore?</Typography>
           <Card>
             <List
@@ -93,7 +93,7 @@ const DemoAssignee = () => {
           data-aos-anchor='[data-aos-create-chore-assignee]'
           data-aos='fade-right'
         >
-          <Typography level='h4'>Assigned :</Typography>
+          <Typography level='h4'>Assigned:</Typography>
           <Typography level='h5'>
             Who is assigned the next due chore?
           </Typography>
@@ -128,7 +128,7 @@ const DemoAssignee = () => {
           data-aos-anchor='[data-aos-create-chore-assignee]'
           data-aos='fade-right'
         >
-          <Typography level='h4'>Picking Mode :</Typography>
+          <Typography level='h4'>Picking Mode:</Typography>
           <Typography level='h5'>
             How to pick the next assignee for the following chore?
           </Typography>


### PR DESCRIPTION
Hi,

just a tiny PR for some minor changes in the strings used in the UI, to make things bit more consistent.
* removed spaces before a colon
  * I know that this is the norm for French, but it is "bad style" in English
* in `ChoreEdit.jsx`: Capitalized the first letter and removed the dot, to match the style of the the other "FormHelperText" in that view


Thanks!