### PR TITLE
fix: remove optional=false from .npmrc to fix esbuild installation

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,2 @@
-optional=false
 fund=false
 audit=false


### PR DESCRIPTION
## Summary
- Removes `optional=false` setting from `.npmrc` that was preventing esbuild's platform-specific binary from being downloaded
- Fixes `npm install` failure with error: `Expected "0.21.5" but got "0.18.20"`

## Problem
The `optional=false` setting in `.npmrc` blocked esbuild's optionalDependencies (platform-specific binaries like `@esbuild/darwin-arm64`). Without the correct binary, esbuild's postinstall validation failed when it found a stale cached binary.

## Troubleshooting performed
1. `rm -rf node_modules && npm install` - same error
2. `npm cache clean --force` - same error  
3. Checked for global esbuild installations - none found
4. Reviewed npm config → found `optional=false` in `.npmrc`
5. `npm install --include=optional` - succeeded
6. Removed `optional=false` to permanently fix

## Test plan
- [ ] Run `npm install` on a clean clone
- [ ] Verify esbuild binary is correct version (`node_modules/.bin/esbuild --version` should show `0.21.5`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)