### PR TITLE
Ignore Cmd/Ctrl+Shift+A to avoid conflict with Chrome tab search shortcut

### DIFF
--- a/src/views/Chores/ArchivedTasks.jsx
+++ b/src/views/Chores/ArchivedTasks.jsx
@@ -110,6 +110,7 @@ const ArchivedTasks = () => {
       // Ctrl/Cmd + A to select all
       if (
         isHoldingCmdOrCtrl &&
+        !event.shiftKey &&
         event.key === 'a' &&
         !['INPUT', 'TEXTAREA'].includes(document.activeElement.tagName)
       ) {

--- a/src/views/Chores/MyChores.jsx
+++ b/src/views/Chores/MyChores.jsx
@@ -338,6 +338,7 @@ const MyChores = () => {
       // Ctrl/Cmd + A to select all - works both in and out of multi-select mode
       else if (
         isHoldingCmdOrCtrl &&
+        !event.shiftKey &&
         event.key === 'a' &&
         !['INPUT', 'TEXTAREA'].includes(document.activeElement.tagName)
       ) {


### PR DESCRIPTION
Currently, the My Chores and Archived Tasks pages have a Cmd/Ctrl+A shortcut.

However, the keyboard shortcut is implemented in a way that also means it responds to Cmd/Ctrl+Shift+A, which isn't necessary and blocks the recently introduced default keyboard shortcut for tab search in Chrome.

This PR fixes the keyboard shortcut implementation to ignore Cmd/Ctrl+Shift+A to allow for the Chrome tab search shortcut to work.