### PR TITLE
Rotate chore on schedule

### DIFF
--- a/src/views/ChoreEdit/ChoreEdit.jsx
+++ b/src/views/ChoreEdit/ChoreEdit.jsx
@@ -76,6 +76,7 @@ const ChoreEdit = () => {
   const [assignees, setAssignees] = useState([])
   const [performers, setPerformers] = useState([])
   const [assignStrategy, setAssignStrategy] = useState(ASSIGN_STRATEGIES[2])
+  const [rotateEvery, setRotateEvery] = useState(null)
   const [dueDate, setDueDate] = useState(null)
   const [assignedTo, setAssignedTo] = useState(-1)
   const [frequencyType, setFrequencyType] = useState('once')
@@ -236,6 +237,7 @@ const ChoreEdit = () => {
       frequencyMetadata: frequencyMetadata,
       assignedTo: assignStrategy === 'no_assignee' ? null : assignedTo,
       assignStrategy: assignStrategy,
+      rotateEvery: rotateEvery > 0 ? rotateEvery : null,
       isRolling: isRolling,
       isActive: isActive,
       notification: isNotificable,
@@ -342,6 +344,7 @@ const ChoreEdit = () => {
           ? data.res.assignStrategy
           : ASSIGN_STRATEGIES[2],
       )
+      setRotateEvery(data.res.rotateEvery || null)
       setIsRolling(data.res.isRolling)
       setIsActive(data.res.isActive)
       setSubTasks(data.res.subTasks ? data.res.subTasks : [])
@@ -798,6 +801,55 @@ const ChoreEdit = () => {
                   ))}
                 </List>
               </Card>
+
+              {/* Rotate Every - only show for rotation strategies with multiple assignees */}
+              {assignees.length > 1 &&
+                !['keep_last_assigned', 'no_assignee'].includes(assignStrategy) && (
+                  <Box mt={2}>
+                    <FormControl>
+                      <Checkbox
+                        checked={rotateEvery !== null && rotateEvery > 0}
+                        onChange={e => {
+                          if (e.target.checked) {
+                            setRotateEvery(1)
+                          } else {
+                            setRotateEvery(null)
+                          }
+                        }}
+                        label='Rotate after a set number of completions'
+                      />
+                      <FormHelperText>
+                        By default, assignee rotates on every completion
+                      </FormHelperText>
+                    </FormControl>
+                    {rotateEvery !== null && rotateEvery > 0 && (
+                      <Box mt={1} sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                        <Typography level='body-md'>Rotate every</Typography>
+                        <Input
+                          type='number'
+                          value={rotateEvery}
+                          onChange={e => {
+                            const val = e.target.value
+                            if (val === '' || val === null) {
+                              setRotateEvery(1)
+                            } else {
+                              const parsed = parseInt(val, 10)
+                              setRotateEvery(parsed > 0 ? parsed : 1)
+                            }
+                          }}
+                          slotProps={{
+                            input: {
+                              min: 1,
+                              max: 365,
+                            },
+                          }}
+                          sx={{ width: '80px' }}
+                        />
+                        <Typography level='body-md'>completion(s)</Typography>
+                      </Box>
+                    )}
+                  </Box>
+                )}
             </Box>
           </>
         )}


### PR DESCRIPTION
This is the accompanying FE change to https://github.com/donetick/donetick/pull/455

This feature adds the ability to rotate a chore on a schedule that is not every completion. It fits the use case where there is a daily chore, but rotation among kids is weekly.