### PR TITLE
Change nth_day_of_month to week_of_month

### DIFF
--- a/src/views/ChoreEdit/ChoreEdit.jsx
+++ b/src/views/ChoreEdit/ChoreEdit.jsx
@@ -161,7 +161,7 @@ const ChoreEdit = () => {
     // Validate advanced scheduling patterns
     if (
       frequencyType === 'days_of_the_week' &&
-      frequencyMetadata?.weekPattern === 'nth_day_of_month' &&
+      frequencyMetadata?.weekPattern === 'week_of_month' &&
       (!frequencyMetadata?.occurrences ||
         frequencyMetadata.occurrences.length === 0)
     ) {

--- a/src/views/ChoreEdit/RepeatSection.jsx
+++ b/src/views/ChoreEdit/RepeatSection.jsx
@@ -65,7 +65,7 @@ const DAYS = [
 
 const WEEK_PATTERNS = {
   every_week: 'Every week',
-  nth_day_of_month: 'Specific occurrences in the month',
+  week_of_month: 'Specific occurrences in the month',
 }
 
 const DAY_OCCURRENCE_OPTIONS = [
@@ -92,7 +92,7 @@ const generateSchedulePreview = metadata => {
   }
 
   if (
-    metadata.weekPattern === 'nth_day_of_month' &&
+    metadata.weekPattern === 'week_of_month' &&
     metadata.occurrences?.length
   ) {
     const occurrenceStr = metadata.occurrences
@@ -299,7 +299,7 @@ const RepeatOnSections = ({
                         Task repeats every week on selected days
                       </FormHelperText>
                     )}
-                    {value === 'nth_day_of_month' && (
+                    {value === 'week_of_month' && (
                       <FormHelperText>
                         Task repeats on specific day occurrences each month
                         (e.g., 1st Monday, 3rd Friday)
@@ -309,7 +309,7 @@ const RepeatOnSections = ({
                 ))}
               </RadioGroup>
 
-              {frequencyMetadata?.weekPattern === 'nth_day_of_month' && (
+              {frequencyMetadata?.weekPattern === 'week_of_month' && (
                 <Box mt={2}>
                   <Typography level='body-sm' mb={1}>
                     Select which occurrences of the selected days:

--- a/src/views/components/CustomParsers.js
+++ b/src/views/components/CustomParsers.js
@@ -430,7 +430,7 @@ export const parseRepeatV2 = inputSentence => {
 
         result.frequencyType = 'days_of_the_week'
         result.frequencyMetadata.days = [VALID_DAYS[dayName].toLowerCase()]
-        result.frequencyMetadata.weekPattern = 'nth_day_of_month'
+        result.frequencyMetadata.weekPattern = 'week_of_month'
         result.frequencyMetadata.occurrences = [occurrence]
 
         const startIndex = inputSentence
@@ -489,7 +489,7 @@ export const parseRepeatV2 = inputSentence => {
 
         result.frequencyType = 'days_of_the_week'
         result.frequencyMetadata.days = [VALID_DAYS[dayName2].toLowerCase()]
-        result.frequencyMetadata.weekPattern = 'nth_day_of_month'
+        result.frequencyMetadata.weekPattern = 'week_of_month'
         result.frequencyMetadata.occurrences = occurrences
 
         const startIndex2 = inputSentence


### PR DESCRIPTION
Original issue for this is here: https://github.com/donetick/donetick/issues/451
The donetick server does not like a week pattern of `nth_day_of_month`. The [logic](https://github.com/donetick/donetick/blob/main/internal/chore/scheduler.go#L121) for this case appears to be under `week_of_month`. It looks like the UI is just using the wrong constant. I did a find and replace to fix this. Here is my test:
[Screencast_20260116_114527.webm](https://github.com/user-attachments/assets/308b9e09-c384-40d4-9dba-55d7566cb62a)