### PR TITLE
Calculate QuickSchedule from Date.now() not empty date

### DIFF
--- a/src/views/components/ChoreActionMenu.jsx
+++ b/src/views/components/ChoreActionMenu.jsx
@@ -129,7 +129,7 @@ const ChoreActionMenu = ({
   }
 
   const getQuickScheduleDate = option => {
-    const now = new Date()
+    const now = new Date(Date.now())
     const today = new Date(now.getFullYear(), now.getMonth(), now.getDate())
 
     switch (option) {


### PR DESCRIPTION
The chore's quick reschedule feature was not working since it always tried to calculate the next event from an empty date object.