### PR TITLE
Add "Donetick" name to title bar

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -123,6 +123,11 @@ function App() {
     registerCapacitorListeners()
   }, [])
 
+  // Set document title
+  useEffect(() => {
+    document.title = 'Donetick';
+  }, [])
+
   return (
     <>
       <NetworkBanner />


### PR DESCRIPTION
Fix for the titlebar on the chores "main" page.

Related issue: 
[https://github.com/donetick/donetick/issues/407](https://github.com/donetick/donetick/issues/407)