### PR TITLE
Labels not available between different users in same circle fix

### DIFF
--- a/src/utils/Fetcher.jsx
+++ b/src/utils/Fetcher.jsx
@@ -284,9 +284,11 @@ const GetAllCircleMembers = async () => {
 }
 
 const UpdateMemberRole = async (memberId, role) => {
+  var memberHeaders = HEADERS()
+  memberHeaders[`Content-Type`] = `application/json`
   return Fetch(`/circles/members/role`, {
     method: 'PUT',
-    headers: HEADERS(),
+    headers: memberHeaders,
     body: JSON.stringify({ role, memberId }),
   })
 }


### PR DESCRIPTION
the "role" could not be parsed on backend because the request was sent as text/plain

Related issue: https://github.com/donetick/donetick/issues/321