### PR TITLE
fix: keyboard covers password field on Android

### DIFF
--- a/android/app/capacitor.build.gradle
+++ b/android/app/capacitor.build.gradle
@@ -13,6 +13,7 @@ dependencies {
     implementation project(':capacitor-app')
     implementation project(':capacitor-browser')
     implementation project(':capacitor-device')
+    implementation project(':capacitor-keyboard')
     implementation project(':capacitor-local-notifications')
     implementation project(':capacitor-network')
     implementation project(':capacitor-preferences')

--- a/android/capacitor.settings.gradle
+++ b/android/capacitor.settings.gradle
@@ -14,6 +14,9 @@ project(':capacitor-browser').projectDir = new File('../node_modules/@capacitor/
 include ':capacitor-device'
 project(':capacitor-device').projectDir = new File('../node_modules/@capacitor/device/android')
 
+include ':capacitor-keyboard'
+project(':capacitor-keyboard').projectDir = new File('../node_modules/@capacitor/keyboard/android')
+
 include ':capacitor-local-notifications'
 project(':capacitor-local-notifications').projectDir = new File('../node_modules/@capacitor/local-notifications/android')
 

--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -1,4 +1,5 @@
 import type { CapacitorConfig } from '@capacitor/cli';
+import { KeyboardResize } from '@capacitor/keyboard';
 
 const config: CapacitorConfig = {
   appId: 'com.donetick.app',
@@ -8,6 +9,10 @@ const config: CapacitorConfig = {
     allowMixedContent: true,
   },
   plugins: {
+    Keyboard: {
+      resize: KeyboardResize.Native,
+      resizeOnFullScreen: true,
+    },
     PushNotifications: {
       presentationOptions: ['badge', 'sound', 'alert'],
     },
@@ -21,8 +26,8 @@ const config: CapacitorConfig = {
       clientId: process.env.VITE_APP_GOOGLE_CLIENT_ID,
       androidClientId: process.env.VITE_APP_ANDRIOD_CLIENT_ID,
       iosClientId: process.env.VITE_APP_IOS_CLIENT_ID,
-  },
-}
+    },
+  }
 };
 
 export default config;

--- a/ios/App/Podfile
+++ b/ios/App/Podfile
@@ -15,6 +15,7 @@ def capacitor_pods
   pod 'CapacitorApp', :path => '../../node_modules/@capacitor/app'
   pod 'CapacitorBrowser', :path => '../../node_modules/@capacitor/browser'
   pod 'CapacitorDevice', :path => '../../node_modules/@capacitor/device'
+  pod 'CapacitorKeyboard', :path => '../../node_modules/@capacitor/keyboard'
   pod 'CapacitorLocalNotifications', :path => '../../node_modules/@capacitor/local-notifications'
   pod 'CapacitorNetwork', :path => '../../node_modules/@capacitor/network'
   pod 'CapacitorPreferences', :path => '../../node_modules/@capacitor/preferences'

--- a/ios/App/Podfile.lock
+++ b/ios/App/Podfile.lock
@@ -23,6 +23,8 @@ PODS:
   - CapacitorCordova (7.4.3)
   - CapacitorDevice (7.0.2):
     - Capacitor
+  - CapacitorKeyboard (7.0.4):
+    - Capacitor
   - CapacitorLocalNotifications (7.0.2):
     - Capacitor
   - CapacitorNetwork (7.0.2):
@@ -139,6 +141,7 @@ DEPENDENCIES:
   - "CapacitorCommunitySqlite (from `../../node_modules/@capacitor-community/sqlite`)"
   - "CapacitorCordova (from `../../node_modules/@capacitor/ios`)"
   - "CapacitorDevice (from `../../node_modules/@capacitor/device`)"
+  - "CapacitorKeyboard (from `../../node_modules/@capacitor/keyboard`)"
   - "CapacitorLocalNotifications (from `../../node_modules/@capacitor/local-notifications`)"
   - "CapacitorNetwork (from `../../node_modules/@capacitor/network`)"
   - CapacitorPluginSafeArea (from `../../node_modules/capacitor-plugin-safe-area`)
@@ -190,6 +193,8 @@ EXTERNAL SOURCES:
     :path: "../../node_modules/@capacitor/ios"
   CapacitorDevice:
     :path: "../../node_modules/@capacitor/device"
+  CapacitorKeyboard:
+    :path: "../../node_modules/@capacitor/keyboard"
   CapacitorLocalNotifications:
     :path: "../../node_modules/@capacitor/local-notifications"
   CapacitorNetwork:
@@ -219,6 +224,7 @@ SPEC CHECKSUMS:
   CapacitorCommunitySqlite: 8b2c6bab33e3519280811d481f8bd0fa90343e1b
   CapacitorCordova: 435121e81a2df4d0034f0fb11fcefab5104cfdb5
   CapacitorDevice: 81ae78d5d1942707caad79276badd458bf6ec603
+  CapacitorKeyboard: 5660c760113bfa48962817a785879373cf5339c3
   CapacitorLocalNotifications: 665188ae8accd40806129073896fb2b39322d858
   CapacitorNetwork: 695069886b3c5ed514db69aa3d026b8dc3c03a6b
   CapacitorPluginSafeArea: 22031c3436269ca80fac90ec2c94bc7c1e59a81d
@@ -250,6 +256,6 @@ SPEC CHECKSUMS:
   SQLCipher: eb79c64049cb002b4e9fcb30edb7979bf4706dfc
   ZIPFoundation: b8c29ea7ae353b309bc810586181fd073cb3312c
 
-PODFILE CHECKSUM: bb6dcef70c8edc058fe3ba311f08a223fd7dbc66
+PODFILE CHECKSUM: 12bc727e3a3f1811956ae85f3bd3b49c4fa77d61
 
 COCOAPODS: 1.16.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@capacitor/core": "^7.0.0",
         "@capacitor/device": "^7.0.0",
         "@capacitor/ios": "^7.0.0",
+        "@capacitor/keyboard": "^7.0.4",
         "@capacitor/local-notifications": "^7.0.0",
         "@capacitor/network": "^7.0.1",
         "@capacitor/preferences": "^7.0.0",
@@ -1995,6 +1996,15 @@
       "license": "MIT",
       "peerDependencies": {
         "@capacitor/core": "^7.4.0"
+      }
+    },
+    "node_modules/@capacitor/keyboard": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/@capacitor/keyboard/-/keyboard-7.0.4.tgz",
+      "integrity": "sha512-kKHsuDOC0q9iC1XANhQBK35S+hFKx4EfY9I+SEMPR6RuUAIuXQXYaA3+D0LkdRdHIf3OrlTDznPvXQ5Dg2WrCA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=7.0.0"
       }
     },
     "node_modules/@capacitor/local-notifications": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@capacitor/core": "^7.0.0",
     "@capacitor/device": "^7.0.0",
     "@capacitor/ios": "^7.0.0",
+    "@capacitor/keyboard": "^7.0.4",
     "@capacitor/local-notifications": "^7.0.0",
     "@capacitor/network": "^7.0.1",
     "@capacitor/preferences": "^7.0.0",


### PR DESCRIPTION
This PR fixes an issue on android where the onscreen keyboard covers some UI elements, making it difficult to know if the right field is selected without having to manually scroll the viewport.

The capacitor keyboard library helps fix this behavior with the `resize` option for ios, and the `resizeOnFullScreen` for android. Capacitor keyboard config docs: are here https://capacitorjs.com/docs/apis/keyboard#configuration.

~~I have not tested these changes on ios. I don't have an iphone and haven't gotten ios emulation set up locally yet.~~
Edit: I updated the imports for ios, but the keyboard seemed to still cover the fields. This is partially fixed by the display size change in https://github.com/donetick/frontend/pull/66, but probably still needs some follow-up work.

Before:

https://github.com/user-attachments/assets/087179ab-c9e7-48a5-8e9c-0c210a689726

After:

https://github.com/user-attachments/assets/9d9a00ed-a02b-43ba-b972-28c4650f0216

(the "Oops something went wrong" warnings at the start of the recordings are unrelated- part of some other work I'm testing)