### PR TITLE
Show all chores when "Default project" selected

### DIFF
--- a/src/views/Chores/MyChores.jsx
+++ b/src/views/Chores/MyChores.jsx
@@ -225,7 +225,7 @@ const MyChores = () => {
       // Otherwise, use project-filtered chores for section grouping
       if (selectedProject.id === 'default') {
         // Default project: only show tasks without a projectId
-        choresToGroup = chores.filter(chore => !chore.projectId)
+        choresToGroup = chores
       } else {
         // Other projects: use the existing filter function
         choresToGroup = filterByProject(chores, selectedProject.id)


### PR DESCRIPTION
Previously if we select the default project, only chores without project and chores under "default project" is shown. It's a quick fix to show ALL the chores as in "Reset filters"