### PR TITLE
UX / SECURITY: Update placeholder text for displayName input

### DIFF
--- a/src/views/Authorization/Signup.jsx
+++ b/src/views/Authorization/Signup.jsx
@@ -243,7 +243,7 @@ const SignupView = () => {
             name='displayName'
             label='Display Name'
             id='displayName'
-            placeholder='Confirm password'
+            placeholder='How others see your name'
             value={displayName}
             onChange={e => {
               setDisplayNameError(null)


### PR DESCRIPTION
Currently new users are asked to put their pw into the displayName input --> reveiling credentials!!