### PR TITLE
Navigation of filters and chips is now in place instead of navigation to a new site in PWA.

### DIFF
--- a/src/views/Chores/MyChores.jsx
+++ b/src/views/Chores/MyChores.jsx
@@ -599,7 +599,10 @@ const MyChores = () => {
     }
 
     // Always navigate with params (preserves project param)
-    Navigate({ pathname: '/chores', search: params.toString() })
+    Navigate(
+      { pathname: '/chores', search: params.toString() },
+      { replace: true },
+    )
   }
 
   const searchOptions = useMemo(


### PR DESCRIPTION
Previously the filters and chips clicks are navigated to a new site on PWA which means the top left is now a back button instead of the homepage's hamburger menu, this PR fixes the issue.