### PR TITLE
fix: points history to include circle members [for donetick/donetick#362]

### DIFF
--- a/src/views/User/UserPoints.jsx
+++ b/src/views/User/UserPoints.jsx
@@ -62,7 +62,7 @@ const UserPoints = () => {
     data: choresHistoryData,
     isLoading: isChoresHistoryLoading,
     handleLimitChange: handleChoresHistoryLimitChange,
-  } = useChoresHistory(7)
+  } = useChoresHistory(7, true)
 
   const { data: userProfile } = useUserProfile()
   const [selectedUser, setSelectedUser] = useState(userProfile?.id)


### PR DESCRIPTION
### Summary

Fix the Points leaderboard so stats are calculated from all circle members' chore history instead of only the current user's history.

### Problem

On the Points page, other users in the same circle showed their total point balance, but their period-based stats such as completed tasks, average points per task, and period points were missing.

This happened because the Points view called `useChoresHistory(7)` without enabling member history, so `/chores/history` only returned the authenticated user's chore history.

### Fix

`useChoresHistory` expects `true` to be passed to `includeMembers` to send the request for the data of all circle members.

```jsx
export const useChoresHistory = (initialLimit, includeMembers) => {
  const [limit, setLimit] = useState(initialLimit) // Initially, no limit is selected

  const { data, error, isLoading } = useQuery({
    queryKey: ['choresHistory', limit],
    queryFn: async () => {
      const resp = await GetChoresHistory(limit, includeMembers)
      return resp?.res || []
    },
    staleTime: 0,
  })
[...]
}
```

Adding `true` for that parameter fixes the missing data in the points view.

```jsx
  const {
    data: choresHistoryData,
    isLoading: isChoresHistoryLoading,
    handleLimitChange: handleChoresHistoryLimitChange,
  } = useChoresHistory(7, true)
```

This fix was originally proposed by @Hannes5612 in donetick/donetick#476 but that issue was closed and the fix never implemented. That's why I am now creating this PR.

### Testing

- Verified that other circle members now show task count, average points per task, and period points
- Verified that the total point balance display remains unchanged
- Verified that timeframe/period switching still works
- Confirmed the issue described in donetick/donetick#362 is resolved by this change