### PR TITLE
fix(ApiClient): respect force flag in init() to allow customServerUrl reload

### DIFF
--- a/src/utils/ApiClient.js
+++ b/src/utils/ApiClient.js
@@ -17,11 +17,16 @@ class ApiClient {
   }
 
   async init(force = false) {
+    if (force) {
+      this.initPromise = null
+      this.initialized = false
+    }
+
     if (this.initPromise) {
       return this.initPromise
     }
 
-    if (this.initialized && !force) {
+    if (this.initialized) {
       return Promise.resolve()
     }
 


### PR DESCRIPTION
## Problem

When a user changes the Server URL via login settings, the new URL is persisted to Capacitor Preferences but is not picked up by the API client until the app is force-stopped and reopened.

This results in confusing UX: the user updates their self-hosted server URL, taps Save, then attempts to log in — and gets `Login Failed` because the request is still being sent to the previous URL (e.g. the default `API_URL`).

## Root cause

`ApiClient.init(force)` accepts a `force` flag intended to bypass the cached state and re-read `customServerUrl` from Preferences. However, the first check in the function returns the existing `initPromise` whenever it is set, regardless of whether `force` is `true`:

```js
async init(force = false) {
  if (this.initPromise) {        // ← returns stale promise even when force=true
    return this.initPromise
  }
  if (this.initialized && !force) {
    return Promise.resolve()
  }
  this.initPromise = this._doInit()
  return this.initPromise
}
```

After the first init, `initPromise` is a resolved promise that resolves with the original URL. Calling `init(true)` from `LoginSettings.jsx` after the user updates the server URL returns this same resolved promise without ever invoking `_doInit()` again — so `customServerURL` is never updated and subsequent requests keep going to the old URL.

## Fix

Reset `initPromise` and `initialized` at the top of `init()` when `force=true`, so the subsequent checks fall through and `_doInit()` is invoked again to re-read Preferences.

## Reproduction

1. Open the app on a device with `customServerUrl` previously set to default (or empty)
2. Go to login settings, change the server URL to a self-hosted URL, tap **Save**
3. Try to log in
4. Observe: request is sent to the original URL, login fails
5. Force-stop and reopen the app — login now works

After this fix, step 4 succeeds without needing to force-stop.

## Diff

`src/utils/ApiClient.js`: +5 / -1 lines.