### PR TITLE
fix: Set assignee bug

### DIFF
--- a/src/views/ChoreEdit/ChoreEdit.jsx
+++ b/src/views/ChoreEdit/ChoreEdit.jsx
@@ -579,7 +579,7 @@ const ChoreEdit = () => {
     if (assignees.length === 0) {
       setAssignStrategy('no_assignee')
       setAssignedTo(null)
-    } else if (assignees.length === 1) {
+    } else {
       if (!assignees.some(a => a.userId === assignedTo)) {
         setAssignedTo(assignees[0].userId)
       }
@@ -1016,10 +1016,10 @@ const ChoreEdit = () => {
                 }
                 disabled={assignees.length === 0}
                 value={assignedTo > -1 ? assignedTo : null}
-                onChange={(_, newValue) => setAssignedTo(newValue)}
+                onChange={(_, selectedUserId) => setAssignedTo(selectedUserId)}
               >
                 {performers
-                  ?.filter(p => assignees.find(a => a.userId == p.userId))
+                  ?.filter(p => assignees.some(a => a.userId == p.userId))
                   .map((item, index) => (
                     <Option value={item.userId} key={item.displayName}>
                       {item.displayName}

--- a/src/views/ChoreEdit/ChoreEdit.jsx
+++ b/src/views/ChoreEdit/ChoreEdit.jsx
@@ -580,7 +580,9 @@ const ChoreEdit = () => {
       setAssignStrategy('no_assignee')
       setAssignedTo(null)
     } else if (assignees.length === 1) {
-      setAssignedTo(assignees[0].userId)
+      if (!assignees.some(a => a.userId === assignedTo)) {
+        setAssignedTo(assignees[0].userId)
+      }
       if (assignStrategy === 'no_assignee') {
         setAssignStrategy(ASSIGN_STRATEGIES[2]) // default to least_completed
       }
@@ -1014,17 +1016,12 @@ const ChoreEdit = () => {
                 }
                 disabled={assignees.length === 0}
                 value={assignedTo > -1 ? assignedTo : null}
+                onChange={(_, newValue) => setAssignedTo(newValue)}
               >
                 {performers
                   ?.filter(p => assignees.find(a => a.userId == p.userId))
                   .map((item, index) => (
-                    <Option
-                      value={item.userId}
-                      key={item.displayName}
-                      onClick={() => {
-                        setAssignedTo(item.userId)
-                      }}
-                    >
+                    <Option value={item.userId} key={item.displayName}>
                       {item.displayName}
                     </Option>
                   ))}


### PR DESCRIPTION
Fixes a bug that caused setting the assignee to not work properly in some situations:
- Better support for `assignees.length > 1`.
- Use `onChange` instead of `onClick` for better accessibility support.