### PR TITLE
feat(auth): hide password login when disable_password_auth is set (#438)

### DIFF
--- a/src/views/Authorization/LoginView.jsx
+++ b/src/views/Authorization/LoginView.jsx
@@ -105,7 +105,7 @@ const LoginView = () => {
     setChildName('')
     setPassword('')
   }
-  const { data: resource } = useResource()
+  const { data: resource, isLoading: resourceLoading } = useResource()
   const { showError } = useNotification()
   const { isAuthenticated, login: authLogin, user } = useAuth()
   const Navigate = useNavigate()
@@ -411,6 +411,10 @@ const LoginView = () => {
   const showSocialLogin = import.meta.env.VITE_IS_SELF_HOSTED !== 'true'
   const hasSocialOptions =
     showSocialLogin || Boolean(resource?.identity_provider?.client_id)
+  // On SSO-only instances the password form, its divider and the signup link
+  // are hidden. Wait for the resource query to settle first so the form never
+  // flashes before being hidden.
+  const showPasswordAuth = !resourceLoading && !resource?.disable_password_auth
 
   return (
     <AuthShell
@@ -477,7 +481,7 @@ const LoginView = () => {
             Use a different account
           </Button>
         </Box>
-      ) : (
+      ) : showPasswordAuth ? (
         <Box
           component='form'
           onSubmit={handleSubmit}
@@ -554,9 +558,11 @@ const LoginView = () => {
             {loginType === 'sub' ? 'Sign in as sub account' : 'Sign in'}
           </AuthSubmitButton>
         </Box>
-      )}
+      ) : null}
 
-      {hasSocialOptions && <AuthDivider>or continue with</AuthDivider>}
+      {hasSocialOptions && (userProfile || showPasswordAuth) && (
+        <AuthDivider>or continue with</AuthDivider>
+      )}
 
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
         {showSocialLogin && !Capacitor.isNativePlatform() && (
@@ -644,24 +650,26 @@ const LoginView = () => {
         )}
       </Box>
 
-      {!userProfile && !resource?.is_user_creation_disabled && (
-        <Typography
-          level='body-sm'
-          sx={{ mt: 3, textAlign: 'center', color: 'text.secondary' }}
-        >
-          Don&apos;t have an account?{' '}
-          <Link
-            component='button'
-            type='button'
+      {!userProfile &&
+        showPasswordAuth &&
+        !resource?.is_user_creation_disabled && (
+          <Typography
             level='body-sm'
-            fontWeight={600}
-            underline='hover'
-            onClick={() => Navigate('/signup')}
+            sx={{ mt: 3, textAlign: 'center', color: 'text.secondary' }}
           >
-            Create one
-          </Link>
-        </Typography>
-      )}
+            Don&apos;t have an account?{' '}
+            <Link
+              component='button'
+              type='button'
+              level='body-sm'
+              fontWeight={600}
+              underline='hover'
+              onClick={() => Navigate('/signup')}
+            >
+              Create one
+            </Link>
+          </Typography>
+        )}
 
       <MFAVerificationModal
         open={mfaModalOpen}


### PR DESCRIPTION
## Summary

When the backend reports `disable_password_auth`, the login screen hides all username/password UI and shows only the SSO provider button(s). This is the client side of the SSO-only mode from #438.

Part of [#438](https://github.com/donetick/donetick/pull/438). Needs the backend companion: donetick/donetick#699.

## Changes

`src/views/Authorization/LoginView.jsx`:

- Reads `disable_password_auth` (and `isLoading`) from the `useResource()` hook.
- Gates the password field, the Login button, the "Forgot password?" link, and the Sign-up button behind `!resourceLoading && !resource?.disable_password_auth`.
- Leaves the SSO/OAuth provider buttons visible, so an SSO-only instance shows a single login path.
- Uses the `resourceLoading` guard so the password form doesn't flash before the config resolves.

Most of the diff is re-indentation from wrapping the existing blocks in the new conditional. The behavior change is small.

## Notes

This is a UX hint only. The backend rejects password auth with a 403 on its own (see the companion PR), so the protection holds even if a client ignores the flag.

On an SSO-only instance this hides password login for all users, including managed sub-accounts, since the flag is there to route every identity through the external IdP.

## Screenshots
<img width="1422" height="1572" alt="localhost_5173_login" src="https://github.com/user-attachments/assets/65226cef-dbe4-49a2-b8b5-00a2fc1b1074" />

<img width="1422" height="1572" alt="localhost_5173_login (1)" src="https://github.com/user-attachments/assets/3fec2ee7-8a25-47da-84ac-08e0f24f61e5" />
