### PR TITLE
Fixes saving server url login setting

### DIFF
--- a/src/utils/ApiClient.js
+++ b/src/utils/ApiClient.js
@@ -44,6 +44,16 @@ class ApiClient {
     return this.customServerURL
   }
 
+  async setServerURL(url) {
+    const trimmedURL = url ? url.replace(/\/+$/, '') : url
+    await Preferences.set({
+      key: 'customServerUrl',
+      value: trimmedURL,
+    })
+    this.customServerURL = `${trimmedURL || API_URL}/api/v1`
+    this.initialized = true
+  }
+
   async refreshToken() {
     // Check if refresh token is expired BEFORE attempting refresh
     const refreshExpired = await isRefreshTokenExpired()

--- a/src/views/Authorization/LoginSettings.jsx
+++ b/src/views/Authorization/LoginSettings.jsx
@@ -95,14 +95,10 @@ const LoginSettings = () => {
               border: 'moccasin',
               borderRadius: '8px',
             }}
-            onClick={() => {
+            onClick={async () => {
               if (serverURL === '') {
-                Preferences.set({
-                  key: 'customServerUrl',
-                  value: API_URL,
-                }).then(() => {
-                  Navigate('/login')
-                })
+                await apiClient.setServerURL(API_URL)
+                Navigate('/login')
                 return
               }
               if (!isValidServerURL()) {
@@ -113,17 +109,9 @@ const LoginSettings = () => {
                 })
                 return
               }
-              Preferences.set({
-                key: 'customServerUrl',
-                value: serverURL,
-              }).then(async () => {
-                // apiClient.customServerURL = serverURL + '/api/v1's
-                // Force re-initialization to reload from Preferences
-                await apiClient.init(true)
-                // refetch resource queries to update the API URL
-                refetchResource()
-                Navigate('/login')
-              })
+              await apiClient.setServerURL(serverURL)
+              refetchResource()
+              Navigate('/login')
             }}
           >
             Save
@@ -140,13 +128,10 @@ const LoginSettings = () => {
               border: 'moccasin',
               borderRadius: '8px',
             }}
-            onClick={() => {
-              Preferences.set({ key: 'customServerUrl', value: API_URL }).then(
-                () => {
-                  refetchResource()
-                  Navigate('/login')
-                },
-              )
+            onClick={async () => {
+              await apiClient.setServerURL(API_URL)
+              refetchResource()
+              Navigate('/login')
             }}
           >
             Cancel and Reset


### PR DESCRIPTION
Fixes  https://github.com/donetick/donetick/issues/579

The url was being saved to the Preferences, but not updated in the active ApiClient object. These changes should fix that.

- Updates the url in memory to be used by the ApiClient.
- Still sets the url in the Preferences.
- Trims the url to avoid double slashes.