### PR TITLE
fix: sync AVAILABLE_LANGUAGES with shipped locales (add zh-CN; drop duplicate ja)

### DIFF
--- a/src/contexts/LocalizationContext.jsx
+++ b/src/contexts/LocalizationContext.jsx
@@ -28,7 +28,7 @@ export const AVAILABLE_LANGUAGES = [
   { code: 'nl', name: 'Dutch', nativeName: 'Nederlands' },
   { code: 'ja', name: 'Japanese', nativeName: '日本語' },
   { code: 'pt', name: 'Portuguese (Brazil)', nativeName: 'Português (Brasil)' },
-  { code: 'ja', name: 'Japanese', nativeName: '日本語' },
+  { code: 'zh-CN', name: 'Chinese (Simplified)', nativeName: '简体中文' },
 ]
 
 export const LocalizationProvider = ({ children }) => {


### PR DESCRIPTION
## What

The language selector reads `AVAILABLE_LANGUAGES` in
`src/contexts/LocalizationContext.jsx`, which is out of sync with the locale
files in `public/locales/`:

- **Adds Simplified Chinese (`zh-CN`).** It ships a complete translation (key
  structure identical to `en`) but was unreachable in the selector — `zh-CN`
  landed in #132 without a selector entry.
- **Removes the duplicate Japanese (`ja`) entry** (two merges of the "add
  Japanese" work each appended one).

## Note

Arabic (`ar`) was in the original version of this PR but has been **dropped per
maintainer feedback** — surfacing it activates the existing RTL path
(`RTL_LANGUAGES` already includes `ar`), and RTL needs a proper pass first. It
can come back as its own PR once RTL is verified. This PR is now purely the
`zh-CN` fix + `ja` de-dup, with no RTL implications.

## How to verify

- The selector lists Chinese (Simplified) and loads its dictionary with no
  missing keys.
- Japanese appears once, not twice.
