### PR TITLE
fix: localize dates for all shipped languages (import moment locales)

### DIFF
--- a/src/i18n/config.js
+++ b/src/i18n/config.js
@@ -1,5 +1,12 @@
+import 'moment/locale/ar'
+import 'moment/locale/de'
+import 'moment/locale/es'
+import 'moment/locale/fr'
 import 'moment/locale/he'
 import 'moment/locale/ja'
+import 'moment/locale/nl'
+import 'moment/locale/pt'
+import 'moment/locale/zh-cn'
 
 import i18n from 'i18next'
 import LanguageDetector from 'i18next-browser-languagedetector'


### PR DESCRIPTION
Fixes #142.

`LocalizationContext` calls `moment.locale(language)` for the active language, but only `moment/locale/ja` was imported — so moment silently fell back to English date formatting for **de, es, fr, nl, pt, zh-CN, ar** (only `en` and `ja` were localized).

### Change
Import each shipped locale statically in `src/i18n/config.js`, matching the existing `moment/locale/ja` line.

### Why static (not dynamic)
The issue raised static vs dynamic import. I went **static** because it matches the existing pattern, is trivially reviewable, and moment locale bundles are tiny (a few KB each). If you'd rather keep the main bundle leaner, I'm happy to switch to a dynamic `import()` of just the active language's locale — just say the word.

### Testing
- `npm run build` passes; all imported locale files resolve.
- Switching language to e.g. German now renders month/weekday names and relative times ("2 hours ago" → "vor 2 Stunden") in that language.

Note: `ru` is intentionally not included here — it comes with the Russian locale PR (#143).
