### PR TITLE
i18n: extract the task-form picker fields (Part of #145)

### DIFF
--- a/public/locales/en/chores.json
+++ b/public/locales/en/chores.json
@@ -145,7 +145,10 @@
     "highPriority": "High Priority"
   },
   "labels": {
-    "label": "Labels"
+    "label": "Labels",
+    "count_one": "{{count}} label",
+    "count_other": "{{count}} labels",
+    "create": "Create label"
   },
   "actionMenu": {
     "view": "View",
@@ -284,7 +287,8 @@
     "title": "Reminders"
   },
   "assignee": {
-    "anyone": "Anyone"
+    "anyone": "Anyone",
+    "label": "Assignee"
   },
   "filterChip": {
     "cancelAll": "Cancel All Filters",
@@ -376,7 +380,8 @@
     "today": "Today",
     "tomorrow": "Tomorrow",
     "weekend": "Weekend",
-    "nextWeek": "Next week"
+    "nextWeek": "Next week",
+    "due": "Due"
   },
   "photoTask": {
     "title": "Scan photo to create task",
@@ -401,5 +406,32 @@
     "dueAlert": "Due Alert",
     "followUp": "Follow-up",
     "rememberFuture": "Remember for Future Tasks"
+  },
+  "scan": {
+    "failedTitle": "Scan Failed",
+    "cannotScan": "Could not scan the document.",
+    "unreadable": "Could not read the scanned image."
+  },
+  "attachments": {
+    "label": "Attachments",
+    "count_one": "{{count}} file",
+    "count_other": "{{count}} files"
+  },
+  "dueDateClearAria": "Clear due date",
+  "project": {
+    "default": "Default Project",
+    "label": "Project"
+  },
+  "smartInput": {
+    "selectPhoto": "Select photo",
+    "scanToCreate": "Scan to create task"
+  },
+  "voice": {
+    "speakToCreate": "Speak to create tasks"
+  },
+  "subtask": {
+    "namePlaceholder": "Task name...",
+    "delete": "Delete (Shift+Backspace)",
+    "addPlaceholder": "Add new task... (Enter to add)"
   }
 }

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -200,5 +200,6 @@
     "cancelAll": "Cancel All"
   },
   "attachments": "Attachments",
-  "fileNumbered": "File {{index}}"
+  "fileNumbered": "File {{index}}",
+  "unknown": "Unknown"
 }

--- a/src/views/components/AssigneePickerField.jsx
+++ b/src/views/components/AssigneePickerField.jsx
@@ -1,6 +1,7 @@
 import { Person } from '@mui/icons-material'
 
 import BaseOptionPicker from './BaseOptionPicker'
+import { useTranslation } from 'react-i18next'
 
 const ANYONE = 'anyone'
 
@@ -14,11 +15,12 @@ const AssigneePickerField = ({
   onClear,
   values = [],
 }) => {
+  const { t } = useTranslation('chores')
   const options = [
     ...(includeAnyone ? [{ userId: ANYONE, displayName: 'Anyone' }] : []),
     ...members.map(member => ({
       userId: member.userId,
-      displayName: member.displayName || member.username || 'Unknown',
+      displayName: member.displayName || member.username || t('common:unknown'),
     })),
   ]
 
@@ -52,7 +54,7 @@ const AssigneePickerField = ({
       onValuesChange={handleValuesChange}
       onClear={onClear}
       emptyDisplay={emptyDisplay}
-      emptyLabel='Assignee'
+      emptyLabel={t('assignee.label')}
       getItemValue={item => item.userId}
       getItemLabel={item => item.displayName}
       renderTriggerIcon={() => <Person sx={{ fontSize: '20px' }} />}

--- a/src/views/components/AttachmentPickerField.jsx
+++ b/src/views/components/AttachmentPickerField.jsx
@@ -23,6 +23,7 @@ import { useFileUpload } from '../../hooks/useFileUpload'
 import { useNotification } from '../../service/NotificationProvider'
 import { DeleteDraftAttachment } from '../../utils/Fetcher'
 import { imageSourceToFile } from '../../utils/FileConvert'
+import { useTranslation } from 'react-i18next'
 
 const IMAGE_EXTENSIONS = ['jpg', 'jpeg', 'png', 'gif', 'webp', 'bmp', 'svg']
 
@@ -40,6 +41,7 @@ const AttachmentPickerField = ({
   onChange,
   onClear,
 }) => {
+  const { t } = useTranslation('chores')
   const [isOpen, setIsOpen] = useState(false)
   const [isUploading, setIsUploading] = useState(false)
   const buttonRef = useRef(null)
@@ -99,8 +101,8 @@ const AttachmentPickerField = ({
     if (cancelled) return
     if (error || !image) {
       showError({
-        title: 'Scan Failed',
-        message: error || 'Could not scan the document.',
+        title: t('scan.failedTitle'),
+        message: error || t('scan.cannotScan'),
       })
       return
     }
@@ -109,8 +111,8 @@ const AttachmentPickerField = ({
     setIsUploading(false)
     if (!file) {
       showError({
-        title: 'Scan Failed',
-        message: 'Could not read the scanned image.',
+        title: t('scan.failedTitle'),
+        message: t('scan.unreadable'),
       })
       return
     }
@@ -184,8 +186,8 @@ const AttachmentPickerField = ({
             }}
           >
             {isEmpty
-              ? 'Attachments'
-              : `${attachments.length} file${attachments.length !== 1 ? 's' : ''}`}
+              ? t('attachments.label')
+              : t('attachments.count', { count: attachments.length })}
           </Typography>
         </Button>
         {!isEmpty && onClear && (

--- a/src/views/components/DueDatePickerField.jsx
+++ b/src/views/components/DueDatePickerField.jsx
@@ -2,6 +2,7 @@ import { CalendarMonth, Close } from '@mui/icons-material'
 import { Box, Button, IconButton, Typography } from '@mui/joy'
 import moment from 'moment'
 import { useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import DueDatePickerModal from './DueDatePickerModal'
 
 const DueDatePickerField = ({
@@ -15,6 +16,7 @@ const DueDatePickerField = ({
   emptyDisplay = 'icon-text',
   size = 'sm',
 }) => {
+  const { t } = useTranslation('chores')
   const [isOpen, setIsOpen] = useState(false)
 
   const handleSave = ({
@@ -35,7 +37,7 @@ const DueDatePickerField = ({
 
   const dueDateLabel = useMemo(() => {
     if (!dueDateOnly) {
-      return 'Due'
+      return t('duePicker.due')
     }
 
     const formattedDate = moment(dueDateOnly).format('MMM D')
@@ -90,7 +92,7 @@ const DueDatePickerField = ({
         </Button>
         {hasDueDate && onClear && (
           <IconButton
-            aria-label='Clear due date'
+            aria-label={t('dueDateClearAria')}
             size='sm'
             variant='soft'
             color='danger'

--- a/src/views/components/LabelsPickerField.jsx
+++ b/src/views/components/LabelsPickerField.jsx
@@ -1,6 +1,7 @@
 import { Add, Label } from '@mui/icons-material'
 import { Button } from '@mui/joy'
 import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import LabelModal from '../Modals/Inputs/LabelModal'
 import BaseOptionPicker from './BaseOptionPicker'
 
@@ -11,6 +12,7 @@ const LabelsPickerField = ({
   labels = [],
   emptyDisplay = 'icon-text',
 }) => {
+  const { t } = useTranslation('chores')
   const [createOpen, setCreateOpen] = useState(false)
   const [pickerOpen, setPickerOpen] = useState(false)
 
@@ -31,7 +33,7 @@ const LabelsPickerField = ({
         open={pickerOpen}
         onOpenChange={setPickerOpen}
         emptyDisplay={emptyDisplay}
-        emptyLabel='Labels'
+        emptyLabel={t('labels.label')}
         getItemValue={item => item.id}
         getItemLabel={item => item.name}
         getItemColor={item => item.color}
@@ -45,9 +47,9 @@ const LabelsPickerField = ({
           />
         )}
         getTriggerText={({ selectedItems, isEmpty }) => {
-          if (isEmpty) return 'Labels'
+          if (isEmpty) return t('labels.label')
           if (selectedItems.length === 1) return selectedItems[0].name
-          return `${selectedItems.length} labels`
+          return t('labels.count', { count: selectedItems.length })
         }}
         menuMinWidth={220}
         menuFooter={
@@ -63,7 +65,7 @@ const LabelsPickerField = ({
             }}
             sx={{ width: '100%', justifyContent: 'flex-start' }}
           >
-            Create label
+            {t('labels.create')}
           </Button>
         }
       />

--- a/src/views/components/ProjectPickerField.jsx
+++ b/src/views/components/ProjectPickerField.jsx
@@ -1,4 +1,5 @@
 import { FolderOpen } from '@mui/icons-material'
+import { useTranslation } from 'react-i18next'
 import BaseOptionPicker from './BaseOptionPicker'
 
 const ProjectPickerField = ({
@@ -8,8 +9,9 @@ const ProjectPickerField = ({
   projects = [],
   emptyDisplay = 'icon-text',
 }) => {
+  const { t } = useTranslation('chores')
   const options = [
-    { id: 'default', name: 'Default Project', color: '#9CA3AF' },
+    { id: 'default', name: t('project.default'), color: '#9CA3AF' },
     ...projects.map(project => ({
       id: project.id,
       name: project.name,
@@ -24,7 +26,7 @@ const ProjectPickerField = ({
       onChange={onChange}
       onClear={onClear}
       emptyDisplay={emptyDisplay}
-      emptyLabel='Project'
+      emptyLabel={t('project.label')}
       getItemValue={item => item.id}
       getItemLabel={item => item.name}
       getItemColor={item => item.color}
@@ -38,7 +40,7 @@ const ProjectPickerField = ({
         />
       )}
       getTriggerText={({ selectedItems, isEmpty }) =>
-        isEmpty ? 'Project' : selectedItems[0].name
+        isEmpty ? t('project.label') : selectedItems[0].name
       }
       menuMinWidth={240}
     />

--- a/src/views/components/SmartTaskTitleInput.jsx
+++ b/src/views/components/SmartTaskTitleInput.jsx
@@ -1,6 +1,7 @@
 import { CameraEnhance, Mic, PhotoFilter } from '@mui/icons-material'
 import { IconButton, Tooltip, useColorScheme } from '@mui/joy'
 import { useEffect, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import AutocompleteDropdown from '../TestView/AutocompleteDropdown'
 import './SmartTaskTitleInput.css'
 const renderHighlightedText = (text, cursorPosition) => {
@@ -59,6 +60,7 @@ const SmartTaskTitleInput = ({
   onPhotoSelected,
   onVoiceClick,
 }) => {
+  const { t } = useTranslation('chores')
   const { mode, setMode } = useColorScheme()
   const titleInputRef = useRef(null)
   const photoInputRef = useRef(null)
@@ -313,7 +315,11 @@ const SmartTaskTitleInput = ({
           >
             {showPhotoButtons && onPhotoSelected && (
               <>
-                <Tooltip title='Select photo' placement='top' size='sm'>
+                <Tooltip
+                  title={t('smartInput.selectPhoto')}
+                  placement='top'
+                  size='sm'
+                >
                   <IconButton
                     size='sm'
                     variant='plain'
@@ -334,7 +340,7 @@ const SmartTaskTitleInput = ({
               </>
             )}
             {showPhotoButtons && onScanClick && (
-              <Tooltip title='Scan to create task' placement='top' size='sm'>
+              <Tooltip title={t('smartInput.scanToCreate')} placement='top' size='sm'>
                 <IconButton
                   size='sm'
                   variant='plain'
@@ -347,7 +353,7 @@ const SmartTaskTitleInput = ({
               </Tooltip>
             )}
             {showVoiceButton && (
-              <Tooltip title='Speak to create tasks' placement='top' size='sm'>
+              <Tooltip title={t('voice.speakToCreate')} placement='top' size='sm'>
                 <IconButton
                   size='sm'
                   variant='plain'

--- a/src/views/components/SubTask.jsx
+++ b/src/views/components/SubTask.jsx
@@ -30,6 +30,7 @@ import {
 } from '@mui/joy'
 import { useCallback, useRef, useState } from 'react'
 import { flushSync } from 'react-dom'
+import { useTranslation } from 'react-i18next'
 import { useLocalization } from '../../contexts/LocalizationContext'
 import { useImpersonateUser } from '../../contexts/ImpersonateUserContext'
 import { useUserProfile } from '../../queries/UserQueries'
@@ -71,6 +72,7 @@ function SortableItem({
   performers,
 }) {
   const { fmt } = useLocalization()
+  const { t } = useTranslation('chores')
   const { attributes, listeners, setNodeRef, transform, transition } =
     useSortable({ id: task.id })
 
@@ -134,7 +136,7 @@ function SortableItem({
                 },
               }}
               value={task.name}
-              placeholder='Task name...'
+              placeholder={t('subtask.namePlaceholder')}
               onChange={e =>
                 setTasks(prev =>
                   prev.map(t =>
@@ -197,7 +199,7 @@ function SortableItem({
               variant='soft'
               color='danger'
               size='sm'
-              title='Delete (Shift+Backspace)'
+              title={t('subtask.delete')}
               onClick={() =>
                 onKeyDown(
                   {
@@ -247,6 +249,7 @@ const SubTasks = ({
   performers,
   shouldFocus = false,
 }) => {
+  const { t } = useTranslation('chores')
   const [newTask, setNewTask] = useState('')
   const [expandedIds, setExpandedIds] = useState(new Set())
   const { data: userProfile } = useUserProfile()
@@ -673,7 +676,7 @@ const SubTasks = ({
             <ListItem sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
               <Input
                 autoFocus={shouldFocus}
-                placeholder='Add new task... (Enter to add)'
+                placeholder={t('subtask.addPlaceholder')}
                 value={newTask}
                 slotProps={{ input: { ref: addInputRef } }}
                 onChange={e => setNewTask(e.target.value)}


### PR DESCRIPTION
i18n: extract the task-form picker fields (`chores` namespace)

Part of #145. This is the narrowed version of this PR, as announced in
#145 and #168.

The original diff covered twelve files; six of them were rewritten under
me since — the modal unification, #186, and the AddTaskModal autocomplete
work. Those hunks no longer applied, which is why GitHub kept showing
this as conflicting. Rather than resolve conflicts that aren't really
conflicts, this force-push reduces the PR to the seven files that are
still untouched on `develop`:

  AssigneePickerField, AttachmentPickerField, DueDatePickerField,
  LabelsPickerField, ProjectPickerField, SmartTaskTitleInput, SubTask

The rewritten half goes back in the queue behind your work, and I'll
re-extract it against the current shape rather than replaying the old
diff.

Rebased on current `develop`. 16 keys added to `en/chores.json`, 1 to
`en/common.json`. English only — no translations, no behaviour change;
every t() value is verified to appear character-for-character in the code
it replaces.

