### PR TITLE
fix: activity history group headers render as "Invalid date"

### DIFF
--- a/src/views/User/UserActivities.jsx
+++ b/src/views/User/UserActivities.jsx
@@ -54,9 +54,15 @@ const groupByDate = history => {
   const aggregated = {}
   for (let i = 0; i < history.length; i++) {
     const item = history[i]
-    const date = new Date(
-      item.performedAt || item.updatedAt,
-    ).toLocaleDateString()
+    // Key by a stable local ISO day (YYYY-MM-DD) so the render-time
+    // formatter (fmt.date) receives a parseable date instead of a
+    // locale-formatted string, which produced "Invalid date".
+    const d = new Date(item.performedAt || item.updatedAt || item.createdAt)
+    const date = isNaN(d.getTime())
+      ? 'unknown'
+      : `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(
+          d.getDate(),
+        ).padStart(2, '0')}`
     if (!aggregated[date]) {
       aggregated[date] = []
     }
@@ -175,7 +181,7 @@ const ChoreHistoryTimeline = ({
       {Object.entries(groupedHistory).map(([date, items]) => (
         <Box key={date} sx={{ mb: 4 }}>
           <Typography level='title-sm' sx={{ mb: 0.5 }}>
-            {fmt.date(date)}
+            {date === 'unknown' ? '—' : fmt.date(date)}
           </Typography>
           <Divider />
           <Stack spacing={1}>


### PR DESCRIPTION
### Problem

In the activity timeline (`UserActivities`), every group header renders as **"Invalid date"** for most locales.

`groupByDate` builds its grouping key with `toLocaleDateString()`:

```js
const date = new Date(item.performedAt || item.updatedAt).toLocaleDateString()
```

and the timeline then renders that same key back through the localized formatter:

```js
{fmt.date(date)}
```

`fmt.date` hands the string to moment, which cannot reparse a locale-formatted date — `"16.07.2026"`, `"2026/7/16"`, `"16/07/2026"` are all unparseable. The result is a literal `Invalid date` where the day heading should be.

It happens to look fine only where the locale format is close enough to a format moment guesses correctly, which is why it is easy to miss on an `en-US` dev machine.

### Fix

Key the groups on a stable local ISO day (`YYYY-MM-DD`) — a format `fmt.date` parses reliably — instead of a display string. Records with no usable timestamp go into an `unknown` bucket rendered as an em dash, so a missing `performedAt`/`updatedAt` no longer produces `Invalid date` either.

Built the key from local date parts rather than `toISOString()` on purpose: `toISOString()` converts to UTC and would shift activity into the wrong day for anyone east or west of UTC around midnight.

### Notes

- Group ordering is unchanged. The keys are non-integer strings, so object insertion order is preserved exactly as before — groups still follow the order records arrive in.
- No string/i18n changes; this is purely the grouping key.
- Single file, 14 lines. Build is green.
