### PR TITLE
Add privacy control to projects and inherit it on tasks

### DIFF
--- a/src/views/ChoreEdit/ChoreEdit.jsx
+++ b/src/views/ChoreEdit/ChoreEdit.jsx
@@ -470,6 +470,17 @@ const ChoreEdit = () => {
     setShowSaveAssigneeDefault(dirty)
   }, [anyone, assignableTo])
 
+  // A task in a private project is always private: the project's privacy wins over
+  // the task's own setting, so keep the form in sync with the selected project.
+  const selectedProjectIsPrivate = Boolean(
+    projects.find(project => project.id === projectId)?.isPrivate,
+  )
+  useEffect(() => {
+    if (selectedProjectIsPrivate && !isPrivate) {
+      setIsPrivate(true)
+    }
+  }, [selectedProjectIsPrivate, isPrivate])
+
   // Keyboard shortcuts
   useEffect(() => {
     const handleKeyDown = event => {
@@ -1789,26 +1800,38 @@ const ChoreEdit = () => {
             }}
           >
             <FormControl>
-              <Radio overlay value={false} label='Public' />
+              <Radio
+                overlay
+                disabled={selectedProjectIsPrivate}
+                value={false}
+                label='Public'
+              />
               <FormHelperText>Everyone in your circle</FormHelperText>
             </FormControl>
             <FormControl>
               <Radio
                 overlay
-                disabled={assignees.length === 0}
+                disabled={selectedProjectIsPrivate || assignees.length === 0}
                 value={true}
                 label='Limited'
               />
               <FormHelperText>
                 You and others that are assigned to the task
-                {assignees.length === 0
+                {assignees.length === 0 && !selectedProjectIsPrivate
                   ? ' (No assignees selected, Limited option is disabled)'
                   : ''}
               </FormHelperText>
             </FormControl>
           </RadioGroup>
 
-          {showSavePrivacyDefault && (
+          {selectedProjectIsPrivate && (
+            <Typography level='body-sm' color='neutral'>
+              Inherited from the project: tasks in a private project are always
+              private
+            </Typography>
+          )}
+
+          {showSavePrivacyDefault && !selectedProjectIsPrivate && (
             <Box sx={{ mt: 0, display: 'flex', justifyContent: 'start' }}>
               <Button
                 variant='outlined'

--- a/src/views/ChoreEdit/ChoreEdit.jsx
+++ b/src/views/ChoreEdit/ChoreEdit.jsx
@@ -481,6 +481,32 @@ const ChoreEdit = () => {
     }
   }, [selectedProjectIsPrivate, isPrivate])
 
+  // Nobody else can see a private project, so its tasks can only be assigned to its
+  // owner — which is whoever is editing it, since that's who the project is visible
+  // to. The API rejects anything else.
+  useEffect(() => {
+    if (!selectedProjectIsPrivate || !userProfile?.id) {
+      return
+    }
+    const onlySelf =
+      assignableTo.length === 1 && assignableTo[0].userId === userProfile.id
+    if (!onlySelf) {
+      setAssignableTo([{ userId: userProfile.id }])
+    }
+    if (anyone) {
+      setAnyone(false)
+    }
+    if (assignedTo !== userProfile.id) {
+      setAssignedTo(userProfile.id)
+    }
+  }, [
+    selectedProjectIsPrivate,
+    userProfile?.id,
+    assignableTo,
+    anyone,
+    assignedTo,
+  ])
+
   // Keyboard shortcuts
   useEffect(() => {
     const handleKeyDown = event => {
@@ -1189,6 +1215,7 @@ const ChoreEdit = () => {
               <ListItem key={'anyone'}>
                 <Checkbox
                   checked={anyone}
+                  disabled={selectedProjectIsPrivate}
                   onClick={() => {
                     setAnyone(!anyone)
                     setIsPrivate(false)
@@ -1204,7 +1231,7 @@ const ChoreEdit = () => {
                 <ListItem key={item.id}>
                   <Checkbox
                     checked={assignableTo.some(a => a.userId == item.userId)}
-                    disabled={anyone}
+                    disabled={anyone || selectedProjectIsPrivate}
                     onClick={() => {
                       if (anyone) {
                         setAnyone(false)
@@ -1232,6 +1259,12 @@ const ChoreEdit = () => {
               ))}
             </List>
           </Card>
+          {selectedProjectIsPrivate && (
+            <Typography level='body-sm' color='neutral' sx={{ mt: 0.5 }}>
+              Only you can see this project, so its tasks can only be assigned
+              to you
+            </Typography>
+          )}
           <FormControl error={Boolean(errors.assignee)}>
             <FormHelperText error>{Boolean(errors.assignee)}</FormHelperText>
           </FormControl>

--- a/src/views/Modals/Inputs/ProjectModal.jsx
+++ b/src/views/Modals/Inputs/ProjectModal.jsx
@@ -2,12 +2,13 @@ import {
   Avatar,
   Box,
   Button,
-  Checkbox,
   FormControl,
   FormHelperText,
   FormLabel,
   Input,
+  Sheet,
   Stack,
+  Switch,
   Textarea,
   Typography,
 } from '@mui/joy'
@@ -256,22 +257,53 @@ const ProjectModal = ({ isOpen, onClose, onSave, project }) => {
           {/* Privacy */}
           <FormControl>
             <FormLabel>Privacy</FormLabel>
-            <Checkbox
-              checked={isPrivate}
-              onChange={e => setIsPrivate(e.target.checked)}
-              disabled={isSubmitting}
-              overlay
-              label='Private project'
-            />
-            <FormHelperText>
-              {isPrivate
-                ? 'Only you can see this project and its tasks'
-                : 'Everyone in your circle can see this project'}
-            </FormHelperText>
+            <Sheet
+              variant='outlined'
+              sx={{
+                borderRadius: 'sm',
+                px: 1.5,
+                py: 1,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                gap: 2,
+              }}
+            >
+              <Box
+                sx={{
+                  minWidth: 0,
+                  flex: '1 1 auto',
+                  cursor: isSubmitting ? undefined : 'pointer',
+                  userSelect: 'none',
+                }}
+                onClick={
+                  isSubmitting ? undefined : () => setIsPrivate(!isPrivate)
+                }
+              >
+                <Typography level='body-sm' fontWeight='md'>
+                  Private project
+                </Typography>
+                <Typography
+                  level='body-xs'
+                  textColor='text.tertiary'
+                  sx={{ mt: 0.25 }}
+                >
+                  {isPrivate
+                    ? 'Only you can see this project and its tasks'
+                    : 'Everyone in your circle can see this project'}
+                </Typography>
+              </Box>
+              <Switch
+                size='sm'
+                checked={isPrivate}
+                onChange={e => setIsPrivate(e.target.checked)}
+                disabled={isSubmitting}
+              />
+            </Sheet>
             {project && isPrivate !== Boolean(project.isPrivate) && (
               <FormHelperText sx={{ color: 'warning.plainColor' }}>
                 {isPrivate
-                  ? 'Every task in this project will become private'
+                  ? 'Every task in this project will become private and assigned only to you: other assignees are removed and are not restored if you make it public again'
                   : 'Every task in this project will become visible to your circle'}
               </FormHelperText>
             )}

--- a/src/views/Modals/Inputs/ProjectModal.jsx
+++ b/src/views/Modals/Inputs/ProjectModal.jsx
@@ -2,7 +2,9 @@ import {
   Avatar,
   Box,
   Button,
+  Checkbox,
   FormControl,
+  FormHelperText,
   FormLabel,
   Input,
   Stack,
@@ -27,6 +29,7 @@ const ProjectModal = ({ isOpen, onClose, onSave, project }) => {
   const [projectDescription, setProjectDescription] = useState('')
   const [projectColor, setProjectColor] = useState(PROJECT_COLORS[0].value)
   const [projectIcon, setProjectIcon] = useState(PROJECT_ICONS[0].value)
+  const [isPrivate, setIsPrivate] = useState(false)
   const [error, setError] = useState('')
   const [isIconPickerOpen, setIsIconPickerOpen] = useState(false)
 
@@ -42,12 +45,14 @@ const ProjectModal = ({ isOpen, onClose, onSave, project }) => {
         setProjectDescription(project.description || '')
         setProjectColor(project.color || PROJECT_COLORS[0].value)
         setProjectIcon(project.icon || PROJECT_ICONS[0].value)
+        setIsPrivate(Boolean(project.isPrivate))
       } else {
         // Creating new project
         setProjectName('')
         setProjectDescription('')
         setProjectColor(PROJECT_COLORS[0].value)
         setProjectIcon(PROJECT_ICONS[0].value)
+        setIsPrivate(false)
       }
       setError('')
     }
@@ -68,6 +73,7 @@ const ProjectModal = ({ isOpen, onClose, onSave, project }) => {
       description: projectDescription.trim(),
       color: projectColor,
       icon: projectIcon,
+      isPrivate,
     }
 
     if (project) {
@@ -245,6 +251,30 @@ const ProjectModal = ({ isOpen, onClose, onSave, project }) => {
                 />
               ))}
             </Box>
+          </FormControl>
+
+          {/* Privacy */}
+          <FormControl>
+            <FormLabel>Privacy</FormLabel>
+            <Checkbox
+              checked={isPrivate}
+              onChange={e => setIsPrivate(e.target.checked)}
+              disabled={isSubmitting}
+              overlay
+              label='Private project'
+            />
+            <FormHelperText>
+              {isPrivate
+                ? 'Only you can see this project and its tasks'
+                : 'Everyone in your circle can see this project'}
+            </FormHelperText>
+            {project && isPrivate !== Boolean(project.isPrivate) && (
+              <FormHelperText sx={{ color: 'warning.plainColor' }}>
+                {isPrivate
+                  ? 'Every task in this project will become private'
+                  : 'Every task in this project will become visible to your circle'}
+              </FormHelperText>
+            )}
           </FormControl>
 
           {/* Error Message */}

--- a/src/views/Projects/ProjectView.jsx
+++ b/src/views/Projects/ProjectView.jsx
@@ -147,6 +147,22 @@ const ProjectCardContent = ({
               Default
             </Chip>
           )}
+          {project.isPrivate && (
+            <Chip
+              size='sm'
+              variant='soft'
+              color='neutral'
+              sx={{
+                fontSize: 9,
+                height: 16,
+                px: 0.5,
+                ml: 1,
+                fontWeight: 'md',
+              }}
+            >
+              Private
+            </Chip>
+          )}
         </Typography>
 
         {/* Project Info */}

--- a/src/views/components/AddTaskModal.jsx
+++ b/src/views/components/AddTaskModal.jsx
@@ -636,7 +636,13 @@ const TaskInput = ({ onChoreUpdate, isModalOpen, onClose }) => {
     let finalAssignedTo = null
     let finalAssignStrategy = assignStrategy
 
-    if (isAnyoneTask) {
+    if (selectedProjectIsPrivate) {
+      // Nobody else can see a private project, so its tasks stay with its owner —
+      // the user creating them, since that's who the project is visible to.
+      finalAssignees = [{ userId: userProfile?.id }]
+      finalAssignedTo = userProfile?.id
+      finalAssignStrategy = assignStrategy
+    } else if (isAnyoneTask) {
       finalAssignees = []
       finalAssignedTo = null
       finalAssignStrategy = 'no_assignee'

--- a/src/views/components/AddTaskModal.jsx
+++ b/src/views/components/AddTaskModal.jsx
@@ -64,7 +64,7 @@ const TaskInput = ({ onChoreUpdate, isModalOpen, onClose }) => {
   const { data: userLabels, isLoading: userLabelsLoading } = useLabels()
   const { data: circleMembers, isLoading: isCircleMembersLoading } =
     useCircleMembers()
-  const { isLoading: isProjectsLoading } = useProjects()
+  const { data: projects = [], isLoading: isProjectsLoading } = useProjects()
   const createChoreMutation = useCreateChore()
 
   const { data: userProfile } = useUserProfile()
@@ -126,6 +126,17 @@ const TaskInput = ({ onChoreUpdate, isModalOpen, onClose }) => {
   useEffect(() => {
     localAIService.isAvailable().then(setLlmAvailable)
   }, [])
+
+  // A task in a private project is always private: the project's privacy wins over
+  // the task's own setting, so keep the form in sync with the selected project.
+  const selectedProjectIsPrivate = Boolean(
+    projects.find(project => project.id === projectId)?.isPrivate,
+  )
+  useEffect(() => {
+    if (selectedProjectIsPrivate && !isPrivate) {
+      setIsPrivate(true)
+    }
+  }, [selectedProjectIsPrivate, isPrivate])
 
   // Priority colors
   const priorityColors = {
@@ -1067,6 +1078,7 @@ const TaskInput = ({ onChoreUpdate, isModalOpen, onClose }) => {
               hasAssignees={assignees.length > 0}
               isPrivate={isPrivate}
               onIsPrivateChange={setIsPrivate}
+              isPrivacyInherited={selectedProjectIsPrivate}
             />
 
             {hasDescription && (

--- a/src/views/components/AdvancedOptionsSection.jsx
+++ b/src/views/components/AdvancedOptionsSection.jsx
@@ -146,6 +146,7 @@ const AdvancedOptionsSection = ({
   onAssignStrategyChange,
   isPrivate,
   onIsPrivateChange,
+  isPrivacyInherited,
   hasDueDate,
   hasMultipleAssignees,
   hasAssignees,
@@ -250,18 +251,22 @@ const AdvancedOptionsSection = ({
           <FieldRow
             label='Limited visibility'
             description={
-              !hasAssignees
-                ? 'Assign someone to enable limited visibility'
-                : 'Only you and assignees can see this task'
+              isPrivacyInherited
+                ? 'Inherited from the project: tasks in a private project are always private'
+                : !hasAssignees
+                  ? 'Assign someone to enable limited visibility'
+                  : 'Only you and assignees can see this task'
             }
             onLabelClick={
-              hasAssignees ? () => onIsPrivateChange(!isPrivate) : undefined
+              hasAssignees && !isPrivacyInherited
+                ? () => onIsPrivateChange(!isPrivate)
+                : undefined
             }
           >
             <Switch
               size='sm'
               checked={isPrivate}
-              disabled={!hasAssignees}
+              disabled={!hasAssignees || isPrivacyInherited}
               onChange={e => onIsPrivateChange(e.target.checked)}
             />
           </FieldRow>


### PR DESCRIPTION
Frontend side of the project-level privacy discussed in
[donetick/donetick discussion #718](https://github.com/donetick/donetick/discussions/718). **Needs the API change in donetick/donetick#749** to do
anything — without it the checkbox posts a field the backend ignores.

## What's in it

- **Project form** (`ProjectModal`): a "Private project" checkbox, with helper
  text spelling out who can see the project. While editing an existing project,
  changing the flag warns that every task in the project will change visibility
  too, since the backend propagates it.
- **Task editor** (`ChoreEdit`): when the selected project is private, the
  Public/Limited radios are disabled and the task is forced to private, with an
  "Inherited from the project" note. The "Remember for Future Tasks" shortcut is
  hidden in that case — the choice isn't the task's to remember.
- **Quick add** (`AddTaskModal` / `AdvancedOptionsSection`): same treatment for
  the "Limited visibility" switch, disabled with the inherited description.
- **Project list** (`ProjectView`): private projects get a "Private" chip,
  following the existing "Default" chip pattern.

The disabling is UX only: the API forces `is_private` on tasks in a private
project regardless of what the client sends, so an older client can't opt out.

## Verified

`vite build` passes and `eslint` reports no new problems on the touched files
(31 pre-existing problems before and after — `develop` isn't lint-clean today).
Not verified in a browser against a running backend.
