### PR TITLE
Update build.yml to allow pushes to any branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,6 @@ name: Build validation
 
 on:
   push:
-    branches: [main]
   pull_request:
 
 jobs:


### PR DESCRIPTION
Remove branch restriction for push events, which prevents forked projects from running CI checks prior to creating a PR.