### PR TITLE
fix: the fastfile contains a hardcoded app store con... in Fastfile

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -2,7 +2,7 @@ require "shellwords"
 
 default_platform(:ios)
 
-IOS_KEY_PATH = File.expand_path("../ios/AuthKey_84F695CDQ3.p8")
+IOS_KEY_PATH = File.expand_path("../ios/AuthKey_#{ENV['ASC_KEY_ID']}.p8")
 IOS_OUTPUT_DIR = File.expand_path("../build/ios")
 ANDROID_PROJECT_DIR = File.expand_path("../android")
 PLAY_JSON_KEY_PATH = File.expand_path("../android/play-service-account.json")
@@ -42,8 +42,10 @@ platform :ios do
     ipa_path = File.join(IOS_OUTPUT_DIR, "Donetick.ipa")
     UI.user_error!("Missing #{ipa_path} — run `fastlane ios release` first") unless File.exist?(ipa_path)
 
+    UI.user_error!("ASC_KEY_ID is not set (App Store Connect API key ID)") if ENV["ASC_KEY_ID"].to_s.empty?
+
     api_key = app_store_connect_api_key(
-      key_id: ENV["ASC_KEY_ID"] || "84F695CDQ3",
+      key_id: ENV["ASC_KEY_ID"],
       issuer_id: ENV["ASC_ISSUER_ID"],
       key_filepath: IOS_KEY_PATH,
       duration: 1200,


### PR DESCRIPTION
## Summary
Fix high severity security issue in `fastlane/Fastfile`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `fastlane/Fastfile:45` |
| **Assessment** | Likely exploitable |
| **Chain Complexity** | 2-step |

**Description**: The Fastfile contains a hardcoded App Store Connect API key ID (84F695CDQ3) as a fallback value when the ASC_KEY_ID environment variable is not set. While the actual private key is stored externally, the key ID is exposed in the source code and corresponds to a specific key file name (AuthKey_84F695CDQ3.p8).

## Evidence

**Exploitation scenario**: An attacker with access to the repository (via public leak, insider threat, or compromised developer machine) extracts the hardcoded key ID '84F695CDQ3' from fastlane/Fastfile:47.

**Scanner confirmation**: multi_agent_ai rule `V-001` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Threat Model Context

This is a web application - XSS and injection vulnerabilities can affect end users.

## Changes
- `fastlane/Fastfile`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path, and the project builds successfully with this change applied.

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

## Security Invariant
> **Property**: The security boundary is maintained under adversarial input

<details>
<summary>Regression test</summary>

```javascript
const { execSync } = require('child_process');
const fs = require('fs');
const path = require('path');

describe("Fastfile must not expose hardcoded App Store Connect API key ID in environment variable processing", () => {
  const payloads = [
    // Exact exploit case: empty environment variable triggers hardcoded fallback
    { ASC_KEY_ID: '', ASC_ISSUER_ID: 'test-issuer' },
    // Boundary case: whitespace-only value should not be treated as valid
    { ASC_KEY_ID: '   ', ASC_ISSUER_ID: 'test-issuer' },
    // Valid input: proper key ID should be used
    { ASC_KEY_ID: 'CUSTOM_KEY_ID_123', ASC_ISSUER_ID: 'test-issuer' },
    // Adversarial case: null/undefined simulation via unset variable
    { ASC_ISSUER_ID: 'test-issuer' }
  ];

  test.each(payloads)("environment variable $ASC_KEY_ID does not leak hardcoded key ID", async (envVars) => {
    const fastfilePath = path.join(__dirname, '../fastlane/Fastfile');
    const testScript = `
      require 'fastlane'
      require 'json'
      
      # Load the Fastfile
      fastfile = Fastlane::FastFile.new('${fastfilePath}')
      
      # Capture the lane context
      result = {}
      begin
        fastfile.runner.execute(:ios, :beta)
      rescue => e
        result[:error] = e.message
      end
      
      # Check if hardcoded key appears in any output
      output = result.to_json
      puts output
    `;

    const env = { ...process.env, ...envVars };
    // Remove ASC_KEY_ID entirely if it's not in the payload (simulating unset)
    if (!('ASC_KEY_ID' in envVars)) {
      delete env.ASC_KEY_ID;
    }

    try {
      const output = execSync(`ruby -e "${testScript.replace(/\n/g, ';')}"`, {
        env,
        cwd: path.dirname(fastfilePath),
        encoding: 'utf8',
        stdio: ['pipe', 'pipe', 'ignore']
      });

      const parsed = JSON.parse(output);
      const errorMessage = parsed.error || '';
      const outputString = JSON.stringify(parsed);

      // Security property: No hardcoded key ID "84F695CDQ3" should appear in any output/error
      expect(outputString).not.toContain('84F695CDQ3');
      expect(errorMessage).not.toContain('84F695CDQ3');
      
      // Additional check: If ASC_KEY_ID is provided and non-empty/whitespace, it should be used
      if (envVars.ASC_KEY_ID && envVars.ASC_KEY_ID.trim()) {
        expect(outputString).toContain(envVars.ASC_KEY_ID);
      }
    } catch (error) {
      // Even if execution fails, hardcoded key must not appear in error messages
      expect(error.message).not.toContain('84F695CDQ3');
    }
  });
});
```

</details>

This test guards against regressions — it's useful independent of the code change above.

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
