### PR TITLE
fix: apply impersonation filter to View Tasks As feature

### DIFF
--- a/src/views/Chores/MyChores.jsx
+++ b/src/views/Chores/MyChores.jsx
@@ -607,8 +607,17 @@ const MyChores = () => {
       ? quickFilteredChores
       : projectFilteredChores
 
+    // Apply impersonation filter: when viewing tasks as another user,
+    // only show chores assigned to that user
+    let result = baseChores
+    if (impersonatedUser) {
+      result = baseChores.filter(
+        chore => chore.assignedTo === impersonatedUser.userId,
+      )
+    }
+
     if (searchTerm?.length > 0) {
-      const searchableChores = baseChores.map(c => ({
+      const searchableChores = result.map(c => ({
         ...c,
         raw_label: c.labelsV2?.map(l => l.name).join(' '),
       }))
@@ -621,7 +630,7 @@ const MyChores = () => {
       return fuse.search(searchTerm).map(result => result.item)
     }
 
-    return baseChores
+    return result
   }, [
     activeFilterId,
     tempFilter,
@@ -630,6 +639,7 @@ const MyChores = () => {
     quickFilteredChores,
     projectFilteredChores,
     searchTerm,
+    impersonatedUser,
   ])
 
   const { showKeyboardShortcuts } = useKeyboardShortcuts({


### PR DESCRIPTION
## Fix: View Tasks As impersonation filter not applied

### Bug
When selecting "View Tasks As" from the UserSwitcher, the chores list was not filtering to only show tasks assigned to the selected user. The `getFilteredChores` useMemo in `MyChores.jsx` was using `projectFilteredChores` directly without applying the impersonation filter, causing all chores to remain visible regardless of the impersonated user selection.

### Root Cause
The `getFilteredChores` function used `projectFilteredChores` (which only filters by project) as its base, missing the impersonation filter that was only applied in `searchFilteredChores` (from the `useChoreFilters` hook). Since `getFilteredChores` is the primary data source used for rendering the chores list, the impersonation filter was effectively bypassed.

### Fix
Added impersonation filtering to `getFilteredChores`: when `impersonatedUser` is set, the chore list is filtered to only include chores where `chore.assignedTo === impersonatedUser.userId`. This mirrors the same logic already present in `useChoreFilters`.

### Related issue
Closes donetick/donetick#501