### PR TITLE
i18n: extract the strings left behind in already-localized screens (Part of #145)

### DIFF
--- a/public/locales/en/chores.json
+++ b/public/locales/en/chores.json
@@ -70,7 +70,19 @@
       "paused": "Timer Paused",
       "reset": "Reset Timer",
       "delete": "Delete Session"
-    }
+    },
+    "unableUndo": "Failed to undo",
+    "offlineComplete": "You're offline — completion will sync when back online",
+    "unableComplete": "Unable to complete task",
+    "offlineSkip": "You're offline — skip will sync when back online",
+    "unableSkip": "Unable to skip task",
+    "offlineStart": "You're offline — start will sync when back online",
+    "unableStart": "Unable to start task",
+    "offlinePause": "You're offline — pause will sync when back online",
+    "unablePause": "Unable to pause task",
+    "offlineRestore": "You're offline — restore will sync when back online",
+    "restoreFailed": "Failed to restore",
+    "unableRestore": "Unable to restore task"
   },
   "toolbar": {
     "defaultProject": "Default Project"

--- a/public/locales/en/settings.json
+++ b/public/locales/en/settings.json
@@ -348,7 +348,8 @@
     "backupCodesModal": {
       "title": "New Backup Codes",
       "warning": "Your previous backup codes are now invalid. Save these new codes in a safe place. Each code can only be used once."
-    }
+    },
+    "generateCodes": "Generate New Codes"
   },
   "apiTokens": {
     "title": "API Tokens",

--- a/src/views/ChoreEdit/ChoreView.jsx
+++ b/src/views/ChoreEdit/ChoreView.jsx
@@ -280,7 +280,7 @@ const ChoreView = () => {
                   message: t('choreView.taskCompletionUndone'),
                 })
               } else {
-                throw new Error('Failed to undo')
+                throw new Error(t('choreView.unableUndo'))
               }
             } catch (error) {
               showError({
@@ -318,7 +318,7 @@ const ChoreView = () => {
         })
         queryClient.invalidateQueries({ queryKey: ['pendingCommands'] })
         showSuccess({
-          message: "You're offline — completion will sync when back online",
+          message: t('choreView.offlineComplete'),
           undoAction: async () => {
             await commandQueue.cancel(cmdId)
             queryClient.invalidateQueries({ queryKey: ['pendingCommands'] })
@@ -327,7 +327,7 @@ const ChoreView = () => {
       } else {
         showError({
           title: t('choreView.undoFailed'),
-          message: error?.message || 'Unable to complete task',
+          message: error?.message || t('choreView.unableComplete'),
         })
       }
     }
@@ -356,7 +356,7 @@ const ChoreView = () => {
                   message: t('choreView.taskSkipUndone'),
                 })
               } else {
-                throw new Error('Failed to undo')
+                throw new Error(t('choreView.unableUndo'))
               }
             } catch (error) {
               showError({
@@ -376,7 +376,7 @@ const ChoreView = () => {
         )
         queryClient.invalidateQueries({ queryKey: ['pendingCommands'] })
         showSuccess({
-          message: "You're offline — skip will sync when back online",
+          message: t('choreView.offlineSkip'),
           undoAction: async () => {
             await commandQueue.cancel(cmdId)
             queryClient.invalidateQueries({ queryKey: ['pendingCommands'] })
@@ -385,7 +385,7 @@ const ChoreView = () => {
       } else {
         showError({
           title: t('choreView.undoFailed'),
-          message: error?.message || 'Unable to skip task',
+          message: error?.message || t('choreView.unableSkip'),
         })
       }
     }
@@ -411,7 +411,7 @@ const ChoreView = () => {
           setChore(startedChore)
           queryClient.invalidateQueries({ queryKey: ['pendingCommands'] })
           showSuccess({
-            message: "You're offline — start will sync when back online",
+            message: t('choreView.offlineStart'),
             undoAction: async () => {
               await commandQueue.cancel(cmdId)
               queryClient.invalidateQueries({ queryKey: ['pendingCommands'] })
@@ -423,7 +423,7 @@ const ChoreView = () => {
 
         showError({
           title: t('choreView.undoFailed'),
-          message: error?.message || 'Unable to start task',
+          message: error?.message || t('choreView.unableStart'),
         })
       },
     })
@@ -450,7 +450,7 @@ const ChoreView = () => {
           setChore(pausedChore)
           queryClient.invalidateQueries({ queryKey: ['pendingCommands'] })
           showSuccess({
-            message: "You're offline — pause will sync when back online",
+            message: t('choreView.offlinePause'),
             undoAction: async () => {
               await commandQueue.cancel(cmdId)
               queryClient.invalidateQueries({ queryKey: ['pendingCommands'] })
@@ -462,7 +462,7 @@ const ChoreView = () => {
 
         showError({
           title: t('choreView.undoFailed'),
-          message: error?.message || 'Unable to pause task',
+          message: error?.message || t('choreView.unablePause'),
         })
       },
     })
@@ -566,7 +566,7 @@ const ChoreView = () => {
         setChore({ ...chore, isActive: true })
         queryClient.invalidateQueries({ queryKey: ['pendingCommands'] })
         showSuccess({
-          message: "You're offline — restore will sync when back online",
+          message: t('choreView.offlineRestore'),
           undoAction: async () => {
             await commandQueue.cancel(cmdId)
             await offlineDB.saveChores([{ ...chore, isActive: false }])
@@ -576,8 +576,8 @@ const ChoreView = () => {
         })
       } else {
         showError({
-          title: 'Failed to restore',
-          message: error.message || 'Unable to restore task',
+          title: t('choreView.restoreFailed'),
+          message: error.message || t('choreView.unableRestore'),
         })
       }
     }

--- a/src/views/Settings/MFASettings.jsx
+++ b/src/views/Settings/MFASettings.jsx
@@ -249,7 +249,7 @@ const MFASettings = () => {
               size='sm'
               onClick={handleRegenerateBackupCodes}
             >
-              Generate New Codes
+              {t('mfa.generateCodes')}
             </Button>
           </Box>
         </Card>


### PR DESCRIPTION
i18n: extract the strings left behind in already-localized screens

Part of #145.

Two files you localized yourself, each with a handful of strings that the
pass didn't reach:

- `ChoreView` — the offline-sync notices ("You're offline — completion
  will sync when back online" and its skip/start/pause/restore siblings)
  and the error toasts they fall back to. 12 keys added to `en/chores.json`.
- `MFASettings` — the "Generate New Codes" button. 1 key added to
  `en/settings.json`.

Both extend namespaces that already exist, so `src/i18n/config.js` is
untouched and this cannot conflict with my other open PRs.

English only — no translations, no behaviour change. Every t() value is
checked to appear character-for-character in the code it replaces, or to
match the value already in your dictionary for the same key (126 call
sites total across both files).

