### PR TITLE
fix: ActivitiesCard crashes — t() in a prop default has no scope

### DIFF
--- a/src/views/Chores/ActivitesCard.jsx
+++ b/src/views/Chores/ActivitesCard.jsx
@@ -274,7 +274,9 @@ const groupActivitiesByDate = activities => {
   return groups
 }
 
-const ActivitiesCard = ({ title = t('activity.title') }) => {
+const ActivitiesCard = ({ title }) => {
+  const { t } = useTranslation('chores')
+  const displayTitle = title || t('activity.title')
   const [noteViewerConfig, setNoteViewerConfig] = useState({ isOpen: false })
 
   // Use hooks to fetch data
@@ -323,7 +325,7 @@ const ActivitiesCard = ({ title = t('activity.title') }) => {
         }}
       >
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
-          <Typography level='title-md'>{title}</Typography>
+          <Typography level='title-md'>{displayTitle}</Typography>
         </Box>
         <Box
           sx={{
@@ -380,7 +382,7 @@ const ActivitiesCard = ({ title = t('activity.title') }) => {
       >
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
           <EventNote color='' />
-          <Typography level='title-md'>{title}</Typography>
+          <Typography level='title-md'>{displayTitle}</Typography>
         </Box>
         <Box
           sx={{
@@ -425,7 +427,7 @@ const ActivitiesCard = ({ title = t('activity.title') }) => {
         >
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
             <EventNote color='' />
-            <Typography level='title-md'>{title}</Typography>
+            <Typography level='title-md'>{displayTitle}</Typography>
           </Box>
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
             <Chip size='sm' variant='soft' color='neutral'>

--- a/src/views/ChoresOverview.jsx
+++ b/src/views/ChoresOverview.jsx
@@ -33,7 +33,6 @@ import DateModal from './Modals/Inputs/DateModal'
 
 // enum for chore status:
 const CHORE_STATUS = {
-  const { t } = useTranslation('chores')
   NO_DUE_DATE: 'No due date',
   DUE_SOON: 'Soon',
   DUE_NOW: 'Due',
@@ -41,6 +40,7 @@ const CHORE_STATUS = {
 }
 
 const ChoresOverview = () => {
+  const { t } = useTranslation('chores')
   const [chores, setChores] = useState([])
   const [filteredChores, setFilteredChores] = useState([])
   const [performers, setPerformers] = useState([])


### PR DESCRIPTION
`ActivitiesCard` takes its title as `({ title = t('activity.title') })`.
A default parameter is evaluated in the function's own scope, where `t`
does not exist: the only `t` in the file is bound inside `ActivityItem`,
a separate component. `Sidepanel` renders the card without a `title`, and
`activities` is `enabled: true` in `DEFAULT_SIDEPANEL_CONFIG`, so the
default is always evaluated on a desktop-width screen.

The hook moves into the component body and the title falls back there
instead. Same rendered output; three render sites now read `displayTitle`.

This is my regression: it arrived with #216, which described itself as
"no behaviour change". It was not caught because a bundler cannot flag it
— an unbound `t` is indistinguishable from a global — and my checks only
verified that keys and imports existed, not that `t` was in scope. It is
visible in the built bundle: `({title:e=t("activity.title")})` keeps the
literal `t` because the minifier cannot rename a free variable, while a
working call nearby minifies to `q=e("common.confirm")`.

I have added an eslint `no-undef` pass to my own pipeline and run it
before sending anything from now on.


### How to see it

`Sidepanel` renders the card without a `title`, and `activities` is
`enabled: true` in `DEFAULT_SIDEPANEL_CONFIG`, so any logged-in user on a
screen wider than `lg` hits it.

It is also visible without running anything. Build `develop` and grep the
bundle:

```
grep -o '.\{50\}activity\.title.\{15\}' dist/assets/Application-*.js
→ OAe=({title:e=t("activity.title")})=>{const[n,
```

The translator is the bare letter `t` — the minifier cannot rename a free
variable, so it leaves it as written. A working call a few lines away
minifies to `q=e("common.confirm")`, where `e` is the bound `t` from the
enclosing hook. That difference is the whole bug.
