### PR TITLE
Add KeyboardShortcutScopeContext for managing keyboard shortcuts acro…

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -16,6 +16,7 @@ import useAnalyticsIdentity from './analytics/useAnalyticsIdentity'
 import { registerCapacitorListeners } from './CapacitorListener'
 import PageTransition from './components/animations/PageTransition'
 import { ImpersonateUserProvider } from './contexts/ImpersonateUserContext'
+import { KeyboardShortcutScopeProvider } from './contexts/KeyboardShortcutScopeContext'
 import SSEProvider from './contexts/SSEContext'
 import { AuthProvider } from './hooks/useAuth.jsx'
 import useOnboardingGate from './hooks/useOnboardingGate'
@@ -160,7 +161,9 @@ function App() {
       <AuthProvider>
         <SSEProvider>
           <GlobalSearchProvider>
-            <AppContent />
+            <KeyboardShortcutScopeProvider>
+              <AppContent />
+            </KeyboardShortcutScopeProvider>
           </GlobalSearchProvider>
         </SSEProvider>
       </AuthProvider>

--- a/src/contexts/KeyboardShortcutScopeContext.jsx
+++ b/src/contexts/KeyboardShortcutScopeContext.jsx
@@ -1,0 +1,102 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useId,
+  useState,
+} from 'react'
+
+// Three priority tiers for keyboard shortcuts, highest first. A shortcut
+// picks a tier by calling the matching hook; every hook returns the same
+// thing — whether *this* listener's shortcuts should run right now — so call
+// sites all look the same regardless of tier:
+//
+//   const isActive = useXShortcutScope(...)
+//   useEffect(() => {
+//     const handleKeyDown = event => {
+//       if (!isActive) return
+//       if (event.repeat) return
+//       ...
+//     }
+//     ...
+//   }, [isActive, ...])
+//
+// - Modal  (useModalShortcutScope):  modals, drawers, the command palette.
+//   Exclusive — only the topmost open one is active. Use for anything that
+//   visually covers the page and should own the keyboard while open.
+// - Page   (usePageShortcutScope):   the current route's own shortcuts (list
+//   navigation, bulk actions, "open the add-task modal", ...). Active
+//   whenever no Modal-tier scope is open. Pages don't need to coordinate
+//   with each other — routing already ensures only one page is mounted.
+// - Global (useGlobalShortcutScope): always active, everywhere, regardless
+//   of what page or modal is open (e.g. Cmd+K search). Reach for this only
+//   when the shortcut is genuinely meant to work no matter what — it's the
+//   one tier that bypasses scoping, so prefer Page or Modal by default.
+//
+// Only Modal needs real state (the stack below); Page and Global are thin,
+// self-documenting wrappers so a shortcut's tier is visible at its call site
+// instead of being an implicit "well, it just didn't check anything."
+const KeyboardShortcutScopeContext = createContext(null)
+
+export const KeyboardShortcutScopeProvider = ({ children }) => {
+  const [stack, setStack] = useState([])
+
+  const push = useCallback(id => {
+    setStack(prev => (prev.includes(id) ? prev : [...prev, id]))
+  }, [])
+
+  const pop = useCallback(id => {
+    setStack(prev => prev.filter(entry => entry !== id))
+  }, [])
+
+  return (
+    <KeyboardShortcutScopeContext.Provider value={{ push, pop, stack }}>
+      {children}
+    </KeyboardShortcutScopeContext.Provider>
+  )
+}
+
+const useScopeStack = () => {
+  const ctx = useContext(KeyboardShortcutScopeContext)
+  if (!ctx) {
+    throw new Error(
+      'useModalShortcutScope/usePageShortcutScope must be used within a KeyboardShortcutScopeProvider',
+    )
+  }
+  return ctx
+}
+
+// Modal tier. Claims exclusive ownership of keyboard shortcuts while `active`
+// is true (e.g. a modal's isOpen prop). Returns whether this claim is
+// currently the topmost one on the stack — the only claimant whose shortcuts
+// should run. Nested scopes (a modal opened from within another modal, or a
+// command palette opened from inside a drawer) stack correctly: the newest
+// one wins, and the previous owner resumes once it unmounts/closes.
+export const useModalShortcutScope = active => {
+  const id = useId()
+  const { push, pop, stack } = useScopeStack()
+
+  useEffect(() => {
+    if (!active) return undefined
+    push(id)
+    return () => pop(id)
+  }, [active, id, push, pop])
+
+  return active && stack[stack.length - 1] === id
+}
+
+// Page tier. True whenever no Modal-tier scope currently owns the keyboard.
+// Page-level shortcuts (list navigation, bulk actions, opening a modal in
+// the first place, ...) should gate on this instead of each hardcoding a
+// check like `if (someModalOpen) return` for every modal that happens to
+// exist today.
+export const usePageShortcutScope = () => {
+  const { stack } = useScopeStack()
+  return stack.length === 0
+}
+
+// Global tier. Always active — bypasses scoping entirely. Exists so a
+// deliberately-global shortcut says so explicitly at its call site, the same
+// shape as the other two tiers, rather than silently omitting any check.
+export const useGlobalShortcutScope = () => true

--- a/src/search/GlobalSearchContext.jsx
+++ b/src/search/GlobalSearchContext.jsx
@@ -154,7 +154,11 @@ export const GlobalSearchProvider = ({ children }) => {
     const onKeyDown = event => {
       if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'k') {
         event.preventDefault()
-        isOpen ? closeSearch() : openSearch()
+        // Cmd/Ctrl+Shift+K opens search straight into "go to" navigation
+        // mode, mirroring the "/" sigil typed inside the palette itself.
+        // Piggybacking Shift on the existing Cmd/Ctrl+K chord keeps it
+        // discoverable without claiming a whole new key.
+        isOpen ? closeSearch() : openSearch(event.shiftKey ? '/' : '')
       }
     }
     window.addEventListener('keydown', onKeyDown)

--- a/src/views/ChoreEdit/ChoreEdit.jsx
+++ b/src/views/ChoreEdit/ChoreEdit.jsx
@@ -42,6 +42,7 @@ import { useNavigate, useParams, useSearchParams } from 'react-router-dom'
 
 import DurationInput from '../../components/common/DurationInput'
 import KeyboardShortcutHint from '../../components/common/KeyboardShortcutHint'
+import { usePageShortcutScope } from '../../contexts/KeyboardShortcutScopeContext'
 import NotificationTemplate from '../../components/NotificationTemplate.jsx'
 import { useDocumentScanner } from '../../hooks/useDocumentScanner'
 import {
@@ -96,6 +97,9 @@ const NO_DUE_DATE_REQUIRED_TYPE = ['no_repeat', 'once']
 const NO_DUE_DATE_ALLOWED_TYPE = ['trigger']
 const ChoreEdit = () => {
   const { t } = useTranslation('chores')
+  // Page-level shortcuts (save/cancel) must defer to whatever modal
+  // currently owns the keyboard — see KeyboardShortcutScopeContext.
+  const isPageShortcutActive = usePageShortcutScope()
   const { data: userProfile, isLoading: isUserProfileLoading } =
     useUserProfile()
 
@@ -509,6 +513,9 @@ const ChoreEdit = () => {
   // Keyboard shortcuts
   useEffect(() => {
     const handleKeyDown = event => {
+      if (!isPageShortcutActive) return
+      if (event.repeat) return
+
       const isHoldingCmd = event.ctrlKey || event.metaKey
 
       // Show keyboard shortcuts when holding Cmd/Ctrl
@@ -544,7 +551,7 @@ const ChoreEdit = () => {
       window.removeEventListener('keydown', handleKeyDown)
       window.removeEventListener('keyup', handleKeyUp)
     }
-  }, [HandleSaveChore])
+  }, [HandleSaveChore, isPageShortcutActive])
 
   useEffect(() => {
     if (isChoreLoading === false && choreData && choreId) {

--- a/src/views/Chores/ArchivedTasks.jsx
+++ b/src/views/Chores/ArchivedTasks.jsx
@@ -35,6 +35,7 @@ import FilterBar from '../../components/common/FilterBar'
 import KeyboardShortcutHint from '../../components/common/KeyboardShortcutHint'
 import SortAndFilterMenu from '../../components/common/SortAndFilterMenu'
 import { useImpersonateUser } from '../../contexts/ImpersonateUserContext.jsx'
+import { usePageShortcutScope } from '../../contexts/KeyboardShortcutScopeContext'
 import { useFilter } from '../../hooks/useFilter'
 import { useUnArchiveChore } from '../../queries/ChoreQueries'
 import { useCircleMembers, useUserProfile } from '../../queries/UserQueries'
@@ -93,6 +94,9 @@ const applyPendingArchivedState = async chores => {
 
 const ArchivedTasks = () => {
   const { t } = useTranslation('chores')
+  // Page-level shortcuts (bulk restore/delete, etc.) must defer to whatever
+  // modal currently owns the keyboard — see KeyboardShortcutScopeContext.
+  const isPageShortcutActive = usePageShortcutScope()
   const { data: userProfile, isLoading: isUserProfileLoading } =
     useUserProfile()
   const { showError, showSuccess } = useNotification()
@@ -284,6 +288,9 @@ const ArchivedTasks = () => {
   // Keyboard shortcuts
   useEffect(() => {
     const handleKeyDown = event => {
+      if (!isPageShortcutActive) return
+      if (event.repeat) return
+
       const isHoldingCmdOrCtrl = event.ctrlKey || event.metaKey
 
       if (isHoldingCmdOrCtrl) {
@@ -364,7 +371,7 @@ const ArchivedTasks = () => {
       document.removeEventListener('keydown', handleKeyDown)
       document.removeEventListener('keyup', handleKeyUp)
     }
-  }, [isMultiSelectMode, selectedChores.size])
+  }, [isMultiSelectMode, selectedChores.size, isPageShortcutActive])
 
   const searchOptions = {
     keys: ['name', 'raw_label'],

--- a/src/views/Chores/MyChores.jsx
+++ b/src/views/Chores/MyChores.jsx
@@ -660,7 +660,6 @@ const MyChores = () => {
   const { showKeyboardShortcuts } = useKeyboardShortcuts({
     isMultiSelectMode,
     selectedChores,
-    addTaskModalOpen,
     searchTerm,
     searchFilter:
       hasQuickFilters || searchTerm?.length > 0 ? 'filtered' : 'All',

--- a/src/views/Chores/SortAndGrouping.jsx
+++ b/src/views/Chores/SortAndGrouping.jsx
@@ -15,6 +15,7 @@ import { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import KeyboardShortcutHint from '../../components/common/KeyboardShortcutHint'
+import { usePageShortcutScope } from '../../contexts/KeyboardShortcutScopeContext'
 
 const SortAndGrouping = ({
   icon,
@@ -31,6 +32,10 @@ const SortAndGrouping = ({
   useChips,
 }) => {
   const { t } = useTranslation('chores')
+  // Stays mounted underneath modals (it's part of the page toolbar), so its
+  // own Cmd+G must defer to whatever modal currently owns the keyboard —
+  // see KeyboardShortcutScopeContext.
+  const isPageShortcutActive = usePageShortcutScope()
   const [anchorEl, setAnchorEl] = useState(null)
   const [selectedIndex, setSelectedIndex] = useState(0)
   const [isKeyboardNavigating, setIsKeyboardNavigating] = useState(false)
@@ -63,10 +68,15 @@ const SortAndGrouping = ({
   // Keyboard shortcut handler
   useEffect(() => {
     const handleKeyDown = event => {
+      if (!isPageShortcutActive) return
+
       const isHoldingCmdOrCtrl = event.ctrlKey || event.metaKey
 
-      // Cmd/Ctrl + G to open sort menu
+      // Cmd/Ctrl + G to open sort menu. Repeat-guarded so holding the combo
+      // can't toggle the menu open/closed repeatedly; arrow-key navigation
+      // below is deliberately left free to repeat.
       if (isHoldingCmdOrCtrl && event.key === 'g') {
+        if (event.repeat) return
         event.preventDefault()
         if (!anchorEl) {
           setAnchorEl(buttonRef.current)
@@ -148,6 +158,7 @@ const SortAndGrouping = ({
     setSelectedItem,
     setFilter,
     onCreateNewFilter,
+    isPageShortcutActive,
   ])
 
   // Reset selected index when menu opens
@@ -160,6 +171,7 @@ const SortAndGrouping = ({
   // Keyboard shortcut hint handler
   useEffect(() => {
     const handleKeyDown = event => {
+      if (!isPageShortcutActive) return
       if (event.ctrlKey || event.metaKey) {
         setShowKeyboardShortcuts(true)
       }
@@ -177,7 +189,7 @@ const SortAndGrouping = ({
       document.removeEventListener('keydown', handleKeyDown)
       document.removeEventListener('keyup', handleKeyUp)
     }
-  }, [])
+  }, [isPageShortcutActive])
 
   const MenuItem_QuickFilter = props => {
     return (

--- a/src/views/Chores/hooks/useKeyboardShortcuts.js
+++ b/src/views/Chores/hooks/useKeyboardShortcuts.js
@@ -1,8 +1,9 @@
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
+import { usePageShortcutScope } from '../../../contexts/KeyboardShortcutScopeContext'
+
 export const useKeyboardShortcuts = ({
-  addTaskModalOpen,
   choreSections,
   filteredChores,
   handlers,
@@ -14,10 +15,17 @@ export const useKeyboardShortcuts = ({
 }) => {
   const { t } = useTranslation('chores')
   const [showKeyboardShortcuts, setShowKeyboardShortcuts] = useState(false)
+  // Any open modal (add-task, etc.) claims the keyboard for itself — see
+  // KeyboardShortcutScopeContext. These are the page's own shortcuts, so
+  // they go silent whenever something else owns it.
+  const isPageShortcutActive = usePageShortcutScope()
 
   useEffect(() => {
     const handleKeyDown = event => {
-      if (addTaskModalOpen) return
+      if (!isPageShortcutActive) return
+      // Ignore auto-repeat from a held key so e.g. Cmd+S can't toggle
+      // multi-select twice from one physical press.
+      if (event.repeat) return
 
       if (event.ctrlKey || event.metaKey) {
         setShowKeyboardShortcuts(true)
@@ -186,7 +194,7 @@ export const useKeyboardShortcuts = ({
       document.removeEventListener('keydown', handleKeyDown)
       document.removeEventListener('keyup', handleKeyUp)
     }
-  }, [isMultiSelectMode, selectedChores.size, addTaskModalOpen, t])
+  }, [isMultiSelectMode, selectedChores.size, isPageShortcutActive, t])
 
   return { showKeyboardShortcuts }
 }

--- a/src/views/Modals/Inputs/ConfirmationModal.jsx
+++ b/src/views/Modals/Inputs/ConfirmationModal.jsx
@@ -3,11 +3,16 @@ import { useCallback, useEffect, useState } from 'react'
 
 import KeyboardShortcutHint from '../../../components/common/KeyboardShortcutHint'
 import ModalActions from '../../../components/common/ModalActions'
+import { useModalShortcutScope } from '../../../contexts/KeyboardShortcutScopeContext'
 import { useResponsiveModal } from '../../../hooks/useResponsiveModal'
 
 function ConfirmationModal({ config }) {
   const { ResponsiveModal } = useResponsiveModal()
   const [showKeyboardShortcuts, setShowKeyboardShortcuts] = useState(false)
+  // Claims the keyboard while open — if another modal (e.g. a nested
+  // confirmation) opens on top, this one's Y/X/Enter/Escape must stay
+  // silent. See KeyboardShortcutScopeContext.
+  const isShortcutScopeActive = useModalShortcutScope(config?.isOpen)
 
   const handleAction = useCallback(
     isConfirmed => {
@@ -18,7 +23,7 @@ function ConfirmationModal({ config }) {
 
   useEffect(() => {
     const handleKeyDown = event => {
-      if (!config?.isOpen) return
+      if (!isShortcutScopeActive) return
 
       if (event.ctrlKey || event.metaKey) setShowKeyboardShortcuts(true)
 
@@ -50,7 +55,7 @@ function ConfirmationModal({ config }) {
       document.removeEventListener('keydown', handleKeyDown)
       document.removeEventListener('keyup', handleKeyUp)
     }
-  }, [config?.isOpen, config?.color, handleAction])
+  }, [config?.isOpen, config?.color, handleAction, isShortcutScopeActive])
 
   const isDestructive = config?.color === 'danger'
 

--- a/src/views/components/AddTaskModal.jsx
+++ b/src/views/components/AddTaskModal.jsx
@@ -19,6 +19,7 @@ import { useTranslation } from 'react-i18next'
 
 import KeyboardShortcutHint from '../../components/common/KeyboardShortcutHint'
 import ModalActions from '../../components/common/ModalActions'
+import { useModalShortcutScope } from '../../contexts/KeyboardShortcutScopeContext'
 import { useDocumentScanner } from '../../hooks/useDocumentScanner'
 import { useFileUpload } from '../../hooks/useFileUpload'
 import { useResponsiveModal } from '../../hooks/useResponsiveModal'
@@ -188,6 +189,10 @@ const PARSE_DEBOUNCE_MS = 150
 
 const TaskInput = ({ initialMode, isModalOpen, onChoreUpdate, onClose }) => {
   const { t } = useTranslation('chores')
+  // Claims the keyboard while open so background listeners (e.g. the project
+  // selector's own Cmd+E) know to stay out of the way — see
+  // KeyboardShortcutScopeContext.
+  const isShortcutScopeActive = useModalShortcutScope(isModalOpen)
   const { ResponsiveModal } = useResponsiveModal()
   const isMobile = useMediaQuery(theme => theme.breakpoints.down('sm'))
   const pickerEmptyDisplay = isMobile ? 'icon' : 'icon-text'
@@ -409,32 +414,35 @@ const TaskInput = ({ initialMode, isModalOpen, onChoreUpdate, onClose }) => {
         dueDate,
         handleCloseModal,
         hasDescription,
-        isModalOpen,
+        isShortcutScopeActive,
         submitChore,
       } = latestRef.current
+      // Only the modal that currently owns the keyboard (the topmost open
+      // one, if this component is ever nested) should react at all —
+      // otherwise a background instance of this same component would also
+      // process keys meant for whatever's on top of it, including showing
+      // its own shortcut hints.
+      if (!isShortcutScopeActive) return
+      // Holding a key (or a fast physical double-tap that the OS coalesces
+      // into auto-repeat) re-fires 'keydown' for as long as it's down. None
+      // of the shortcuts below are meant to repeat — Cmd+J revealing
+      // subtasks a second time just steals focus away from wherever the
+      // user actually is.
+      if (event.repeat) return
+
       const isHoldingCmd = event.ctrlKey || event.metaKey
       if (isHoldingCmd) {
         setShowKeyboardShortcuts(true)
       }
-      if (
-        isHoldingCmd &&
-        event.key.toLowerCase() === 'e' &&
-        isModalOpen &&
-        !hasDescription
-      ) {
+      if (isHoldingCmd && event.key.toLowerCase() === 'e' && !hasDescription) {
         setHasDescription(true)
         setShowKeyboardShortcuts(false)
       }
-      if (isHoldingCmd && event.key.toLowerCase() === 'j' && isModalOpen) {
+      if (isHoldingCmd && event.key.toLowerCase() === 'j') {
         setHasSubTasks(true)
         setShowKeyboardShortcuts(false)
       }
-      if (
-        isHoldingCmd &&
-        event.key.toLowerCase() === 'b' &&
-        isModalOpen &&
-        !dueDate
-      ) {
+      if (isHoldingCmd && event.key.toLowerCase() === 'b' && !dueDate) {
         const tomorrow = moment().add(1, 'day')
         setDueDateOnly(tomorrow.format('YYYY-MM-DD'))
         setDueDate(tomorrow.endOf('day').format('YYYY-MM-DDTHH:mm:59'))
@@ -442,16 +450,12 @@ const TaskInput = ({ initialMode, isModalOpen, onChoreUpdate, onClose }) => {
         setDueTime(null)
         setShowKeyboardShortcuts(false)
       }
-      if (
-        event.key === 'Enter' &&
-        (event.ctrlKey || event.metaKey) &&
-        isModalOpen
-      ) {
+      if (event.key === 'Enter' && isHoldingCmd) {
         event.preventDefault()
         submitChore()
         return
       }
-      if (event.key === 'Escape' && isModalOpen) {
+      if (event.key === 'Escape') {
         event.preventDefault()
         handleCloseModal()
         return
@@ -1140,6 +1144,7 @@ const TaskInput = ({ initialMode, isModalOpen, onChoreUpdate, onClose }) => {
 
   latestRef.current = {
     isModalOpen,
+    isShortcutScopeActive,
     hasDescription,
     dueDate,
     createChore,

--- a/src/views/components/ProjectSelector.jsx
+++ b/src/views/components/ProjectSelector.jsx
@@ -15,6 +15,7 @@ import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
 
 import KeyboardShortcutHint from '../../components/common/KeyboardShortcutHint'
+import { usePageShortcutScope } from '../../contexts/KeyboardShortcutScopeContext'
 import LABEL_COLORS, {
   getTextColorFromBackgroundColor,
 } from '../../utils/Colors'
@@ -30,6 +31,10 @@ const ProjectSelector = ({
   const { t } = useTranslation('projects')
   const { data: projects = [], isLoading } = useProjects()
   const navigate = useNavigate()
+  // Stays mounted underneath modals (it's part of the page toolbar), so its
+  // own Cmd+E must defer to whatever modal currently owns the keyboard —
+  // see KeyboardShortcutScopeContext.
+  const isPageShortcutActive = usePageShortcutScope()
 
   const [anchorEl, setAnchorEl] = useState(null)
   const [selectedIndex, setSelectedIndex] = useState(0)
@@ -104,10 +109,15 @@ const ProjectSelector = ({
   // Keyboard shortcut handler
   useEffect(() => {
     const handleKeyDown = event => {
+      if (!isPageShortcutActive) return
+
       const isHoldingCmdOrCtrl = event.ctrlKey || event.metaKey
 
-      // Cmd/Ctrl + E to open project menu
+      // Cmd/Ctrl + E to open project menu. Repeat-guarded so holding the
+      // combo can't toggle the menu open/closed repeatedly; arrow-key
+      // navigation below is deliberately left free to repeat.
       if (isHoldingCmdOrCtrl && event.key === 'e') {
+        if (event.repeat) return
         event.preventDefault()
         if (!anchorEl) {
           setAnchorEl(buttonRef.current)
@@ -165,7 +175,13 @@ const ProjectSelector = ({
     return () => {
       document.removeEventListener('keydown', handleKeyDown)
     }
-  }, [anchorEl, selectedIndex, defaultProjects, isKeyboardNavigating])
+  }, [
+    anchorEl,
+    selectedIndex,
+    defaultProjects,
+    isKeyboardNavigating,
+    isPageShortcutActive,
+  ])
 
   // Reset selected index when menu opens
   useEffect(() => {


### PR DESCRIPTION
The shortcut CMD + J is supposed to open a new task modal, but it is also used for adding a subtask within it. As a result, when the modal opens, the subtask field gets highlighted. To fix this, we should limit the shortcut's scope to the page modal only.