### PR TITLE
feat(chores): add 'skip automatically when late' option to the task form

### DIFF
--- a/public/locales/en/chores.json
+++ b/public/locales/en/chores.json
@@ -709,6 +709,8 @@
     "rescheduleFromDueHelp": "the next task will be scheduled from the original due date, even if the previous task was completed late",
     "rescheduleFromCompletion": "Reschedule from completion date",
     "rescheduleFromCompletionHelp": "the next task will be scheduled from the actual completion date of the previous task",
+    "autoSkipWhenLate": "Skip automatically when late",
+    "autoSkipWhenLateHelp": "if this task is still not done once it is past due, skip it and move on to the next occurrence",
     "notifications": "Notifications",
     "notificationsPlanWarning": "Task notifications are not available in the Basic plan. Upgrade to Plus to receive reminders when tasks are due or completed.",
     "notifyForTask": "Notify for this task",

--- a/src/views/ChoreEdit/ChoreEdit.jsx
+++ b/src/views/ChoreEdit/ChoreEdit.jsx
@@ -139,6 +139,7 @@ const ChoreEdit = () => {
   const [notificationMetadata, setNotificationMetadata] = useState({})
 
   const [isRolling, setIsRolling] = useState(false)
+  const [autoSkipWhenLate, setAutoSkipWhenLate] = useState(false)
   const [isNotificable, setIsNotificable] = useState(false)
   const [isActive, setIsActive] = useState(true)
   const [updatedBy, setUpdatedBy] = useState(0)
@@ -388,6 +389,7 @@ const ChoreEdit = () => {
       assignedTo: assignedToValue,
       assignStrategy: assignStrategyValue,
       isRolling: isRolling,
+      autoSkipWhenLate: autoSkipWhenLate,
       isActive: isActive,
       notification: isNotificable,
       labels: labels.map(l => l.name),
@@ -593,6 +595,7 @@ const ChoreEdit = () => {
           : DEFAULT_ASSIGN_STRATEGY,
       )
       setIsRolling(data.res.isRolling)
+      setAutoSkipWhenLate(Boolean(data.res.autoSkipWhenLate))
       setIsActive(data.res.isActive)
       setSubTasks(data.res.subTasks ? data.res.subTasks : [])
       setProjectId(data.res.projectId || 'default')
@@ -1647,6 +1650,19 @@ const ChoreEdit = () => {
                 </FormHelperText>
               </FormControl>
             </RadioGroup>
+            {!['trigger', 'adaptive'].includes(frequencyType) && (
+              <FormControl sx={{ mt: 1 }}>
+                <Checkbox
+                  checked={autoSkipWhenLate}
+                  onChange={e => setAutoSkipWhenLate(e.target.checked)}
+                  overlay
+                  label={t('choreEdit.autoSkipWhenLate')}
+                />
+                <FormHelperText>
+                  {t('choreEdit.autoSkipWhenLateHelp')}
+                </FormHelperText>
+              </FormControl>
+            )}
           </Box>
         )}
         {/* Section 3.1: Notifications */}


### PR DESCRIPTION
Frontend for: https://github.com/donetick/donetick/pull/824

Adds an autoSkipWhenLate checkbox to the scheduling section of the task create/edit form. It is only offered for repeating tasks, so one-off tasks are never auto-skipped.
<img width="620" height="196" alt="image" src="https://github.com/user-attachments/assets/a842333e-2ac5-4a33-a090-a56bbef75dd3" />

https://github.com/donetick/donetick/discussions/364

