### PR TITLE
feat: support serving the app under a dynamic base path

### DIFF
--- a/src/Config.js
+++ b/src/Config.js
@@ -1,3 +1,7 @@
+// Injected by nginx sub_filter when served through HA ingress; empty string otherwise
+export const BASE_PATH =
+  typeof window !== 'undefined' ? (window.__INGRESS_PATH__ ?? '') : ''
+
 export const API_URL =
   import.meta.env.VITE_APP_API_URL === 'AUTO'
     ? `${window.location.hostname}/api`

--- a/src/MarketingApp.jsx
+++ b/src/MarketingApp.jsx
@@ -3,6 +3,8 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { useEffect } from 'react'
 import { createBrowserRouter, RouterProvider } from 'react-router-dom'
 
+import { BASE_PATH } from './Config'
+
 import { ImpersonateUserProvider } from './contexts/ImpersonateUserContext'
 import { LocalizationProvider } from './contexts/LocalizationContext'
 import ThemeContext from './contexts/ThemeContext'
@@ -29,7 +31,7 @@ const router = createBrowserRouter([
   { path: '/privacy', element: <PrivacyPolicyView /> },
   { path: '/terms', element: <TermsView /> },
   { path: '*', element: <AppRedirect /> },
-])
+], { basename: BASE_PATH || '/' })
 
 const queryClient = new QueryClient({
   defaultOptions: {

--- a/src/contexts/RouterContext.jsx
+++ b/src/contexts/RouterContext.jsx
@@ -1,5 +1,7 @@
 import { createBrowserRouter, RouterProvider } from 'react-router-dom'
 
+import { BASE_PATH } from '../Config'
+
 import App from '@/App'
 import ChoreEdit from '@/views/ChoreEdit/ChoreEdit'
 import Error from '@/views/Error'
@@ -281,7 +283,7 @@ const Router = createBrowserRouter([
       },
     ],
   },
-])
+], { basename: BASE_PATH || '/' })
 
 const RouterContext = ({ children }) => {
   return <RouterProvider router={Router} />

--- a/src/i18n/config.js
+++ b/src/i18n/config.js
@@ -7,6 +7,8 @@ import LanguageDetector from 'i18next-browser-languagedetector'
 import HttpBackend from 'i18next-http-backend'
 import { initReactI18next } from 'react-i18next'
 
+import { BASE_PATH } from '../Config'
+
 i18n
   .use(HttpBackend)
   .use(LanguageDetector)
@@ -20,7 +22,7 @@ i18n
     },
 
     backend: {
-      loadPath: '/locales/{{lng}}/{{ns}}.json',
+      loadPath: `${BASE_PATH}/locales/{{lng}}/{{ns}}.json`,
     },
 
     ns: [

--- a/src/utils/ApiClient.js
+++ b/src/utils/ApiClient.js
@@ -1,6 +1,6 @@
 import { Preferences } from '@capacitor/preferences'
 
-import { API_URL } from '../Config'
+import { API_URL, BASE_PATH } from '../Config'
 import { networkManager } from '../hooks/NetworkManager'
 import {
   recordApiFailure,
@@ -19,7 +19,8 @@ const OAUTH_EXCHANGE_IN_PROGRESS = 'OAuth exchange in progress'
 
 class ApiClient {
   constructor() {
-    this.customServerURL = `${API_URL}/api/v1`
+    // When API_URL is empty (selfhosted mode), fall back to BASE_PATH (HA ingress prefix)
+    this.customServerURL = `${API_URL || BASE_PATH}/api/v1`
     this.isRefreshing = false
     this.failedQueue = []
     this.lastRefreshTime = 0
@@ -46,7 +47,7 @@ class ApiClient {
       key: 'customServerUrl',
     })
 
-    this.customServerURL = `${serverURL || API_URL}/api/v1`
+    this.customServerURL = `${serverURL || API_URL || BASE_PATH}/api/v1`
     this.initialized = true
   }
   getApiURL() {
@@ -196,7 +197,8 @@ class ApiClient {
       console.error('Error during logout', e)
     }
 
-    if (window.location.pathname !== '/login') window.location.href = '/login'
+    const loginPath = `${BASE_PATH}/login`
+    if (window.location.pathname !== loginPath) window.location.href = loginPath
     // fire and forget
   }
   async request(endpoint, options = {}) {

--- a/src/utils/OAuthExchangeState.js
+++ b/src/utils/OAuthExchangeState.js
@@ -1,11 +1,13 @@
+import { BASE_PATH } from '../Config'
+
 // Tracks whether an OAuth authorization-code exchange is currently in flight.
 //
 // During that window the app is legitimately unauthenticated: the deep link has
 // arrived but Authenticating.jsx has not received tokens yet. Any 401 from an
 // unrelated request (background sync, a resumed query) must NOT be treated as an
 // expired session — the forced logout it triggers clears storage and does a hard
-// `window.location.href = '/login'`, which tears down the page and aborts the
-// in-flight code exchange.
+// `window.location.href = BASE_PATH + '/login'`, which tears down the page and
+// aborts the in-flight code exchange.
 let exchangeInProgress = false
 
 export const beginOAuthExchange = () => {
@@ -21,4 +23,5 @@ export const endOAuthExchange = () => {
 // full page load, so nothing has run to set the flag — the pathname check covers
 // that case (and doubles as a backstop if the flag is never cleared).
 export const isOAuthExchangeInProgress = () =>
-  exchangeInProgress || window.location.pathname === '/auth/oauth2'
+  exchangeInProgress ||
+  window.location.pathname === `${BASE_PATH}/auth/oauth2`

--- a/src/views/Authorization/Authenticating.jsx
+++ b/src/views/Authorization/Authenticating.jsx
@@ -6,6 +6,7 @@ import { useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Link, useNavigate, useParams } from 'react-router-dom'
 
+import { BASE_PATH } from '../../Config'
 import { useUserProfile } from '../../queries/UserQueries'
 import { apiClient } from '../../utils/ApiClient'
 import { GetUserProfile } from '../../utils/Fetcher'
@@ -98,7 +99,7 @@ const AuthenticationLoading = () => {
       const baseURL = apiClient.getApiURL()
       const redirectURI = Capacitor.isNativePlatform()
         ? 'donetick://auth/oauth2'
-        : `${window.location.origin}/auth/oauth2`
+        : `${window.location.origin}${BASE_PATH}/auth/oauth2`
       try {
         const response = await fetch(`${baseURL}/auth/oauth2/callback`, {
           method: 'POST',

--- a/src/views/Authorization/LoginView.jsx
+++ b/src/views/Authorization/LoginView.jsx
@@ -14,7 +14,7 @@ import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
 import { LoginSocialGoogle } from 'reactjs-social-login'
 
-import { GOOGLE_CLIENT_ID, REDIRECT_URL } from '../../Config'
+import { BASE_PATH, GOOGLE_CLIENT_ID, REDIRECT_URL } from '../../Config'
 import { useAuth } from '../../hooks/useAuth.jsx'
 import { useResource } from '../../queries/ResourceQueries'
 import { useUserProfile } from '../../queries/UserQueries.jsx'
@@ -409,7 +409,7 @@ const LoginView = () => {
       const params = new URLSearchParams({
         response_type: 'code',
         client_id: resource?.identity_provider?.client_id,
-        redirect_uri: `${window.location.origin}/auth/oauth2`,
+        redirect_uri: `${window.location.origin}${BASE_PATH}/auth/oauth2`,
         scope: 'openid profile email',
         state: state,
       })

--- a/src/views/ChoreEdit/ChoreView.jsx
+++ b/src/views/ChoreEdit/ChoreView.jsx
@@ -39,6 +39,7 @@ import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom'
 
+import { BASE_PATH } from '../../Config'
 import { useImpersonateUser } from '../../contexts/ImpersonateUserContext.jsx'
 import { useLocalization } from '../../contexts/LocalizationContext'
 import { useDescriptionHtml } from '../../hooks/useDescriptionHtml'
@@ -118,7 +119,7 @@ const hasHtmlTags = value => /<\/?[a-z][\s\S]*>/i.test(value)
 const getNFCUrl = choreId =>
   Capacitor.getPlatform() === 'android' || Capacitor.getPlatform() === 'ios'
     ? `donetick://chores/${choreId}`
-    : `${window.location.origin}/chores/${choreId}`
+    : `${window.location.origin}${BASE_PATH}/chores/${choreId}`
 
 const ChoreView = () => {
   const { t } = useTranslation('chores')

--- a/src/views/Chores/components/ChoreModals.jsx
+++ b/src/views/Chores/components/ChoreModals.jsx
@@ -1,6 +1,8 @@
 import { Capacitor } from '@capacitor/core'
 import { useTranslation } from 'react-i18next'
 
+import { BASE_PATH } from '../../../Config'
+
 import DueDatePickerModal, {
   combineDueDate,
   splitDueDate,
@@ -14,7 +16,7 @@ import WriteNFCModal from '../../Modals/Inputs/WriteNFCModal'
 const getNFCUrl = choreId =>
   Capacitor.getPlatform() === 'android' || Capacitor.getPlatform() === 'ios'
     ? `donetick://chores/${choreId}`
-    : `${window.location.origin}/chores/${choreId}`
+    : `${window.location.origin}${BASE_PATH}/chores/${choreId}`
 
 const ChoreModals = ({
   activeModal,

--- a/src/views/components/Loading.jsx
+++ b/src/views/components/Loading.jsx
@@ -3,6 +3,7 @@ import { Typography } from '@mui/material'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
+import { BASE_PATH } from '../../Config'
 import { networkManager } from '../../hooks/NetworkManager'
 import Logo from '../../Logo'
 
@@ -63,7 +64,7 @@ const LoadingComponent = () => {
           color='primary'
           sx={{ mt: 4 }}
           onClick={() => {
-            window.location.href = '/' // navigate back to the home page
+            window.location.href = BASE_PATH || '/' // navigate back to the home page
           }}
         >
           {t('navigateBack')}

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -14,6 +14,11 @@ export default ({ command, mode }) => {
     command === 'build' && Boolean(personalApiKey && projectId)
 
   return defineConfig({
+    // Selfhosted builds (incl. the HA addon) may be served from an arbitrary,
+    // sometimes dynamic sub-path (e.g. HA ingress' per-session token prefix).
+    // Relative asset URLs let the browser resolve them against whatever path
+    // the page was actually loaded from, instead of the domain root.
+    base: mode === 'selfhosted' ? './' : '/',
     define: {
       'import.meta.env.VITE_APP_VERSION': JSON.stringify(pkg.version),
     },
@@ -54,12 +59,12 @@ export default ({ command, mode }) => {
           icons: [
             {
               sizes: '192x192',
-              src: '/android-chrome-192x192.png',
+              src: 'android-chrome-192x192.png',
               type: 'image/png',
             },
             {
               sizes: '512x512',
-              src: '/android-chrome-512x512.png',
+              src: 'android-chrome-512x512.png',
               type: 'image/png',
             },
             {
@@ -96,7 +101,7 @@ export default ({ command, mode }) => {
           clientsClaim: true, // Take control of uncontrolled clients as soon as the service worker becomes active
           maximumFileSizeToCacheInBytes: 6000000, // 6MB
           //Exclude API and Swagger routes from service worker navigation fallback
-          navigateFallback: '/index.html',
+          navigateFallback: mode === 'selfhosted' ? './index.html' : '/index.html',
           navigateFallbackDenylist: [
             /^\/api\//, // Exclude all API routes
             /^\/swagger/, // Exclude all Swagger routes


### PR DESCRIPTION
##Summary

Vite defaults to base: '/', so a selfhosted build's index.html referenced its JS/CSS bundle, manifest, and favicons with absolute paths. That breaks whenever the app is served from a path prefix that isn't known at build time (e.g. Home Assistant's per-session ingress token prefix, or any reverse proxy mounting the app under a sub-path): the browser resolves "/assets/..." against the hardcoded / (the domain root) instead of that prefix, and the request never reaches the proxy.

## Motivation

Merging this change will open the door to addressing donetick/hassio-addons#17 (home assistant ingress) and donetick/donetick#147 (authentication using homeassistant ingress' tokens) - as well as provide a viable means of remote access for users of the homeassistant addon (thereby addressing donetick/hassio-addons#23)

## Changes

- vite.config.mjs: base: './' for --mode selfhosted builds, so built asset references are relative and resolve correctly regardless of the path the page was actually loaded from. Also makes the PWA manifest icons and navigateFallback relative in that mode. The default (non-selfhosted) build is unaffected.
- Config.js: new BASE_PATH export, sourced from window.__INGRESS_PATH__ (or equivalent) when present, empty string otherwise.

The vite base fix only covers paths baked in at build time. Anything a component constructs at runtime from window.location.origin or a hardcoded absolute path needed the same fix applied, here is the list of those locations:

- RouterContext.jsx, MarketingApp.jsx: router basename
- ApiClient.js: API base URL, forced-logout redirect and its pathname guard
- i18n/config.js: i18next-http-backend loadPath for locale JSON files
- OAuthExchangeState.js: pathname check that backstops the forced-logout redirect during an in-flight OAuth exchange
- LoginView.jsx, Authenticating.jsx: OAuth2 redirect_uri (must match exactly between the authorize call and the token exchange)
- ChoreModals.jsx, ChoreEdit/ChoreView.jsx: chore share-link (getNFCUrl)
- components/Loading.jsx: "back to home" fallback button