### PR TITLE
Add reward store UI: browse, redeem, and manage rewards

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -55,6 +55,7 @@
     "filters": "Filters",
     "activities": "Activities",
     "points": "Points",
+    "rewards": "Rewards",
     "settings": "Settings",
     "reportBug": "Report an Issue"
   },

--- a/public/locales/en/rewards.json
+++ b/public/locales/en/rewards.json
@@ -1,0 +1,49 @@
+{
+  "blurb": "Spend your points on rewards, or manage the reward catalog if you're an admin. Available: {{points}} points.",
+  "redeem": "Redeem",
+  "notEnoughPoints": "Not enough points",
+  "approve": "Approve",
+  "reject": "Reject",
+  "pointsCost_one": "{{count}} point",
+  "pointsCost_other": "{{count}} points",
+  "tabs": {
+    "store": "Store",
+    "requests": "Requests"
+  },
+  "status": {
+    "pending": "Pending",
+    "approved": "Approved",
+    "rejected": "Rejected"
+  },
+  "delete": {
+    "title": "Delete Reward",
+    "message": "Are you sure you want to delete this reward? It will no longer be available to redeem."
+  },
+  "redeemConfirm": {
+    "title": "Redeem Reward",
+    "message": "Request \"{{name}}\" for {{cost}} points? An admin will need to approve it."
+  },
+  "requests": {
+    "emptyTitle": "No redemption requests",
+    "emptyDescription": "Redemption requests will show up here once someone redeems a reward."
+  },
+  "modal": {
+    "errorEmptyName": "Name cannot be empty",
+    "errorInvalidCost": "Points cost must be a number greater than 0",
+    "saveFailedTitle": "Failed to save reward",
+    "saveFailedMessage": "Unable to save reward. Please try again.",
+    "name": "Name",
+    "description": "Description",
+    "pointsCost": "Points cost",
+    "active": "Active",
+    "editTitle": "Edit Reward",
+    "addTitle": "Add Reward",
+    "saveChanges": "Save Changes",
+    "addReward": "Add Reward"
+  },
+  "view": {
+    "emptyTitle": "No rewards yet",
+    "emptyDescription": "Add a reward — like movie night or a treat — that circle members can redeem their points for.",
+    "createReward": "Create a reward"
+  }
+}

--- a/src/contexts/RouterContext.jsx
+++ b/src/contexts/RouterContext.jsx
@@ -40,6 +40,7 @@ import PaymentCancelledView from '../views/Payments/PaymentFailView'
 import PaymentSuccessView from '../views/Payments/PaymentSuccessView'
 import PrivacyPolicyView from '../views/PrivacyPolicy/PrivacyPolicyView'
 import ProjectView from '../views/Projects/ProjectView'
+import RewardsView from '../views/Rewards/RewardsView'
 import APITokenSettings from '../views/Settings/APITokenSettings'
 import LocalizationSettings from '../views/Settings/LocalizationSettings'
 import MFASettings from '../views/Settings/MFASettings'
@@ -267,6 +268,10 @@ const Router = createBrowserRouter([
       {
         path: 'labels/:labelId',
         element: <LabelDetailView />,
+      },
+      {
+        path: 'rewards/',
+        element: <RewardsView />,
       },
       {
         path: 'members/:userId',

--- a/src/i18n/config.js
+++ b/src/i18n/config.js
@@ -35,6 +35,7 @@ i18n
       'projects',
       'timer',
       'points',
+      'rewards',
     ],
     defaultNS: 'common',
 

--- a/src/utils/Fetcher.jsx
+++ b/src/utils/Fetcher.jsx
@@ -612,6 +612,70 @@ const RedeemPoints = (userId, points, circleID) => {
     body: JSON.stringify({ points, userId }),
   })
 }
+
+const GetRewards = async () => {
+  const resp = await Fetch(`/rewards`, {
+    method: 'GET',
+    headers: HEADERS(),
+  })
+  return resp.json()
+}
+
+const CreateReward = reward => {
+  return Fetch(`/rewards`, {
+    method: 'POST',
+    headers: HEADERS(),
+    body: JSON.stringify(reward),
+  }).then(response => response.json())
+}
+
+const UpdateReward = (id, reward) => {
+  return Fetch(`/rewards/${id}`, {
+    method: 'PUT',
+    headers: HEADERS(),
+    body: JSON.stringify(reward),
+  }).then(response => response.json())
+}
+
+const DeleteReward = id => {
+  return Fetch(`/rewards/${id}`, {
+    method: 'DELETE',
+    headers: HEADERS(),
+  })
+}
+
+const RedeemReward = (id, note) => {
+  return Fetch(`/rewards/${id}/redeem`, {
+    method: 'POST',
+    headers: HEADERS(),
+    body: JSON.stringify({ note: note || null }),
+  }).then(response => response.json())
+}
+
+const GetRedemptions = async (status = null) => {
+  const query = status ? `?status=${status}` : ''
+  const resp = await Fetch(`/rewards/redemptions${query}`, {
+    method: 'GET',
+    headers: HEADERS(),
+  })
+  return resp.json()
+}
+
+const ApproveRedemption = id => {
+  return Fetch(`/rewards/redemptions/${id}/approve`, {
+    method: 'POST',
+    headers: HEADERS(),
+    body: JSON.stringify({}),
+  })
+}
+
+const RejectRedemption = (id, note) => {
+  return Fetch(`/rewards/redemptions/${id}/reject`, {
+    method: 'POST',
+    headers: HEADERS(),
+    body: JSON.stringify({ note: note || null }),
+  })
+}
 const RefreshToken = async () => {
   const basedURL = apiManager.getApiURL()
 
@@ -987,6 +1051,7 @@ const TrackFilterUsage = id => {
 export {
   AcceptCircleMemberRequest,
   ApproveChore,
+  ApproveRedemption,
   ArchiveChore,
   CancelSubscription,
   ChangePassword,
@@ -1002,6 +1067,7 @@ export {
   CreateLabel,
   CreateLongLiveToken,
   CreateProject,
+  CreateReward,
   CreateThing,
   DeleteChildUser,
   DeleteChore,
@@ -1013,6 +1079,7 @@ export {
   DeleteLabel,
   DeleteLongLiveToken,
   DeleteProject,
+  DeleteReward,
   DeleteThing,
   DeleteTimeSession,
   DeleteUser,
@@ -1040,7 +1107,9 @@ export {
   GetPinnedFilters,
   GetProjectById,
   GetProjects,
+  GetRedemptions,
   GetResource,
+  GetRewards,
   GetStorageUsage,
   GetSubscriptionSession,
   GetThingHistory,
@@ -1057,10 +1126,12 @@ export {
   PutNotificationTarget,
   PutWebhookURL,
   RedeemPoints,
+  RedeemReward,
   RefreshToken,
   RegenerateBackupCodes,
   RegisterDeviceToken,
   RejectChore,
+  RejectRedemption,
   ResetChoreTimer,
   ResetPassword,
   RestoreBackup,
@@ -1087,6 +1158,7 @@ export {
   UpdateNotificationTarget,
   UpdatePassword,
   UpdateProject,
+  UpdateReward,
   UpdateThingState,
   UpdateTimeSession,
   UpdateUserDetails,

--- a/src/views/Modals/Inputs/RewardModal.jsx
+++ b/src/views/Modals/Inputs/RewardModal.jsx
@@ -1,0 +1,156 @@
+import { Box, FormControl, Input, Switch, Textarea, Typography } from '@mui/joy'
+import { useQueryClient } from '@tanstack/react-query'
+import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import ModalActions from '../../../components/common/ModalActions'
+import { useResponsiveModal } from '../../../hooks/useResponsiveModal.js'
+import { useNotification } from '../../../service/NotificationProvider.jsx'
+import { CreateReward, UpdateReward } from '../../../utils/Fetcher'
+
+function RewardModal({ isOpen, onClose, reward }) {
+  const { t } = useTranslation('rewards')
+  const { ResponsiveModal } = useResponsiveModal()
+
+  const [name, setName] = useState('')
+  const [description, setDescription] = useState('')
+  const [pointsCost, setPointsCost] = useState('')
+  const [isActive, setIsActive] = useState(true)
+  const [error, setError] = useState('')
+  const queryClient = useQueryClient()
+  const { showError } = useNotification()
+
+  useEffect(() => {
+    if (reward) {
+      setName(reward.name)
+      setDescription(reward.description || '')
+      setPointsCost(String(reward.pointsCost))
+      setIsActive(reward.isActive)
+    } else {
+      setName('')
+      setDescription('')
+      setPointsCost('')
+      setIsActive(true)
+    }
+    setError('')
+  }, [reward])
+
+  const validate = () => {
+    if (!name.trim()) {
+      setError(t('modal.errorEmptyName'))
+      return false
+    }
+    const cost = Number(pointsCost)
+    if (!Number.isFinite(cost) || cost <= 0) {
+      setError(t('modal.errorInvalidCost'))
+      return false
+    }
+    return true
+  }
+
+  const handleSave = () => {
+    if (!validate()) return
+
+    const payload = {
+      name,
+      description,
+      pointsCost: Number(pointsCost),
+      isActive,
+    }
+
+    const save = reward?.id
+      ? UpdateReward(reward.id, payload)
+      : CreateReward(payload)
+
+    save
+      .then(res => {
+        if (res?.error) {
+          setError(res.error)
+        } else {
+          queryClient.invalidateQueries('rewards')
+          onClose()
+        }
+      })
+      .catch(() => {
+        showError({
+          title: t('modal.saveFailedTitle'),
+          message: t('modal.saveFailedMessage'),
+        })
+      })
+  }
+
+  return (
+    <ResponsiveModal
+      open={isOpen}
+      onClose={onClose}
+      size='lg'
+      fullWidth={true}
+      title={reward ? t('modal.editTitle') : t('modal.addTitle')}
+      footer={
+        <ModalActions
+          secondary={{ label: t('common:cancel'), onClick: onClose }}
+          primary={{
+            label: reward ? t('modal.saveChanges') : t('modal.addReward'),
+            onClick: handleSave,
+          }}
+        />
+      }
+    >
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+        <FormControl>
+          <Typography gutterBottom level='body-sm' alignSelf='start'>
+            {t('modal.name')}
+          </Typography>
+          <Input
+            fullWidth
+            value={name}
+            onChange={e => setName(e.target.value)}
+          />
+        </FormControl>
+
+        <FormControl>
+          <Typography gutterBottom level='body-sm' alignSelf='start'>
+            {t('modal.description')}
+          </Typography>
+          <Textarea
+            minRows={2}
+            value={description}
+            onChange={e => setDescription(e.target.value)}
+          />
+        </FormControl>
+
+        <FormControl>
+          <Typography gutterBottom level='body-sm' alignSelf='start'>
+            {t('modal.pointsCost')}
+          </Typography>
+          <Input
+            fullWidth
+            type='number'
+            slotProps={{ input: { min: 1 } }}
+            value={pointsCost}
+            onChange={e => setPointsCost(e.target.value)}
+          />
+        </FormControl>
+
+        <FormControl
+          orientation='horizontal'
+          sx={{ justifyContent: 'space-between' }}
+        >
+          <Typography level='body-sm'>{t('modal.active')}</Typography>
+          <Switch
+            checked={isActive}
+            onChange={e => setIsActive(e.target.checked)}
+          />
+        </FormControl>
+
+        {error && (
+          <Typography color='warning' level='body-sm'>
+            {error}
+          </Typography>
+        )}
+      </Box>
+    </ResponsiveModal>
+  )
+}
+
+export default RewardModal

--- a/src/views/Rewards/RewardQueries.jsx
+++ b/src/views/Rewards/RewardQueries.jsx
@@ -1,0 +1,36 @@
+import { useQuery } from '@tanstack/react-query'
+
+import { GetRedemptions, GetRewards } from '../../utils/Fetcher'
+import { offlineDB } from '../../utils/OfflineDB'
+
+export const useRewards = () => {
+  return useQuery({
+    queryKey: ['rewards'],
+    queryFn: async () => {
+      try {
+        const data = await GetRewards()
+        const rewards = Array.isArray(data) ? data : []
+        if (rewards.length > 0) {
+          offlineDB.saveKV('rewards', rewards)
+        }
+        return rewards
+      } catch {
+        const cached = await offlineDB.getKV('rewards')
+        if (Array.isArray(cached)) return cached
+        return []
+      }
+    },
+  })
+}
+
+// status: 'pending' | 'approved' | 'rejected' | undefined (all, scoped to the
+// caller — admins/managers get the whole circle, everyone else gets their own)
+export const useRedemptions = status => {
+  return useQuery({
+    queryKey: ['redemptions', status || 'all'],
+    queryFn: async () => {
+      const data = await GetRedemptions(status)
+      return Array.isArray(data) ? data : []
+    },
+  })
+}

--- a/src/views/Rewards/RewardsView.jsx
+++ b/src/views/Rewards/RewardsView.jsx
@@ -1,0 +1,391 @@
+import { Add, Delete, Edit, Redeem } from '@mui/icons-material'
+import {
+  Box,
+  Button,
+  Card,
+  Chip,
+  CircularProgress,
+  Container,
+  IconButton,
+  Stack,
+  Tab,
+  TabList,
+  TabPanel,
+  Tabs,
+  Typography,
+} from '@mui/joy'
+import { useQueryClient } from '@tanstack/react-query'
+import { useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import EmptyState from '../../components/common/EmptyState'
+import { useCircleMembers, useUserProfile } from '../../queries/UserQueries'
+import {
+  ApproveRedemption,
+  DeleteReward,
+  RedeemReward,
+  RejectRedemption,
+} from '../../utils/Fetcher'
+import { getSafeBottomStyles } from '../../utils/SafeAreaUtils'
+import ConfirmationModal from '../Modals/Inputs/ConfirmationModal'
+import RewardModal from '../Modals/Inputs/RewardModal'
+import { useRedemptions, useRewards } from './RewardQueries'
+
+const RewardCard = ({
+  availablePoints,
+  isAdmin,
+  onDelete,
+  onEdit,
+  onRedeem,
+  reward,
+}) => {
+  const { t } = useTranslation('rewards')
+  const canAfford = availablePoints >= reward.pointsCost
+
+  return (
+    <Card variant='outlined' sx={{ gap: 1 }}>
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'flex-start',
+        }}
+      >
+        <Typography level='title-md'>{reward.name}</Typography>
+        {isAdmin && (
+          <Stack direction='row' gap={0.5}>
+            <IconButton
+              size='sm'
+              variant='plain'
+              onClick={() => onEdit(reward)}
+            >
+              <Edit sx={{ fontSize: 18 }} />
+            </IconButton>
+            <IconButton
+              size='sm'
+              variant='plain'
+              color='danger'
+              onClick={() => onDelete(reward)}
+            >
+              <Delete sx={{ fontSize: 18 }} />
+            </IconButton>
+          </Stack>
+        )}
+      </Box>
+      {reward.description && (
+        <Typography level='body-sm' sx={{ color: 'text.secondary' }}>
+          {reward.description}
+        </Typography>
+      )}
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          mt: 1,
+        }}
+      >
+        <Chip variant='soft' color='primary'>
+          {t('pointsCost', { count: reward.pointsCost })}
+        </Chip>
+        <Button
+          size='sm'
+          startDecorator={<Redeem />}
+          disabled={!canAfford}
+          onClick={() => onRedeem(reward)}
+        >
+          {canAfford ? t('redeem') : t('notEnoughPoints')}
+        </Button>
+      </Box>
+    </Card>
+  )
+}
+
+const RedemptionRow = ({ isAdmin, onApprove, onReject, redemption }) => {
+  const { t } = useTranslation('rewards')
+  const statusColor =
+    redemption.status === 1
+      ? 'success'
+      : redemption.status === 2
+        ? 'danger'
+        : 'warning'
+  const statusLabel =
+    redemption.status === 1
+      ? t('status.approved')
+      : redemption.status === 2
+        ? t('status.rejected')
+        : t('status.pending')
+
+  return (
+    <Card variant='outlined' sx={{ p: 1.5 }}>
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+        }}
+      >
+        <Box>
+          <Typography level='title-sm'>{redemption.rewardName}</Typography>
+          <Typography level='body-xs' sx={{ color: 'text.secondary' }}>
+            {t('pointsCost', { count: redemption.pointsCost })}
+          </Typography>
+        </Box>
+        <Stack direction='row' gap={1} alignItems='center'>
+          <Chip size='sm' variant='soft' color={statusColor}>
+            {statusLabel}
+          </Chip>
+          {isAdmin && redemption.status === 0 && (
+            <>
+              <Button
+                size='sm'
+                color='success'
+                onClick={() => onApprove(redemption)}
+              >
+                {t('approve')}
+              </Button>
+              <Button
+                size='sm'
+                color='danger'
+                variant='soft'
+                onClick={() => onReject(redemption)}
+              >
+                {t('reject')}
+              </Button>
+            </>
+          )}
+        </Stack>
+      </Box>
+    </Card>
+  )
+}
+
+const RewardsView = () => {
+  const { t } = useTranslation('rewards')
+  const queryClient = useQueryClient()
+
+  const { data: rewards = [], isLoading: rewardsLoading } = useRewards()
+  const { data: userProfile } = useUserProfile()
+  const { data: circleMembersData } = useCircleMembers()
+  const { data: myRedemptions = [] } = useRedemptions()
+  const { data: pendingRedemptions = [] } = useRedemptions('pending')
+
+  const [modalOpen, setModalOpen] = useState(false)
+  const [currentReward, setCurrentReward] = useState(null)
+  const [confirmationModel, setConfirmationModel] = useState({})
+  const [tab, setTab] = useState('store')
+
+  const currentMember = useMemo(
+    () => circleMembersData?.res?.find(m => m.userId === userProfile?.id),
+    [circleMembersData, userProfile],
+  )
+  const isAdmin =
+    currentMember?.role === 'admin' || currentMember?.role === 'manager'
+  const availablePoints = currentMember
+    ? (currentMember.points || 0) - (currentMember.pointsRedeemed || 0)
+    : 0
+
+  const activeRewards = useMemo(
+    () => rewards.filter(r => r.isActive),
+    [rewards],
+  )
+
+  const invalidateAll = () => {
+    queryClient.invalidateQueries('rewards')
+    queryClient.invalidateQueries('redemptions')
+    queryClient.invalidateQueries('allCircleMembers')
+  }
+
+  const handleAdd = () => {
+    setCurrentReward(null)
+    setModalOpen(true)
+  }
+  const handleEdit = reward => {
+    setCurrentReward(reward)
+    setModalOpen(true)
+  }
+  const handleDelete = reward => {
+    setConfirmationModel({
+      isOpen: true,
+      title: t('delete.title'),
+      message: t('delete.message'),
+      confirmText: t('common:delete'),
+      color: 'danger',
+      cancelText: t('common:cancel'),
+      onClose: confirmed => {
+        if (confirmed) {
+          DeleteReward(reward.id).then(invalidateAll)
+        }
+        setConfirmationModel({})
+      },
+    })
+  }
+  const handleRedeem = reward => {
+    setConfirmationModel({
+      isOpen: true,
+      title: t('redeemConfirm.title'),
+      message: t('redeemConfirm.message', {
+        name: reward.name,
+        cost: reward.pointsCost,
+      }),
+      confirmText: t('redeem'),
+      color: 'primary',
+      cancelText: t('common:cancel'),
+      onClose: confirmed => {
+        if (confirmed) {
+          RedeemReward(reward.id).then(invalidateAll)
+        }
+        setConfirmationModel({})
+      },
+    })
+  }
+  const handleApprove = redemption => {
+    ApproveRedemption(redemption.id).then(invalidateAll)
+  }
+  const handleReject = redemption => {
+    RejectRedemption(redemption.id).then(invalidateAll)
+  }
+
+  if (rewardsLoading) {
+    return (
+      <Box
+        display='flex'
+        justifyContent='center'
+        alignItems='center'
+        height='100vh'
+      >
+        <CircularProgress />
+      </Box>
+    )
+  }
+
+  return (
+    <Container maxWidth='md' sx={{ px: 0 }}>
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 2, p: 2 }}>
+        <Stack sx={{ flex: 1 }}>
+          <Typography
+            level='h3'
+            sx={{ fontWeight: 'lg', color: 'text.primary' }}
+          >
+            {t('common:navigation.rewards')}
+          </Typography>
+          <Typography level='body-sm' sx={{ color: 'text.secondary' }}>
+            {t('blurb', { points: availablePoints })}
+          </Typography>
+        </Stack>
+      </Box>
+
+      <Tabs value={tab} onChange={(_, v) => setTab(v)} sx={{ px: 2 }}>
+        <TabList>
+          <Tab value='store'>{t('tabs.store')}</Tab>
+          <Tab value='requests'>
+            {t('tabs.requests')}
+            {isAdmin && pendingRedemptions.length > 0 && (
+              <Chip size='sm' variant='solid' color='warning' sx={{ ml: 1 }}>
+                {pendingRedemptions.length}
+              </Chip>
+            )}
+          </Tab>
+        </TabList>
+
+        <TabPanel value='store' sx={{ px: 0 }}>
+          <Box sx={{ px: 2, py: 2 }}>
+            {activeRewards.length === 0 ? (
+              <EmptyState
+                fullHeight
+                icon={<Redeem />}
+                title={t('view.emptyTitle')}
+                description={t('view.emptyDescription')}
+                primaryAction={
+                  isAdmin
+                    ? {
+                        label: t('view.createReward'),
+                        startDecorator: <Add />,
+                        onClick: handleAdd,
+                      }
+                    : undefined
+                }
+              />
+            ) : (
+              <Box
+                sx={{
+                  display: 'grid',
+                  gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr' },
+                  gap: 2,
+                }}
+              >
+                {activeRewards.map(reward => (
+                  <RewardCard
+                    key={reward.id}
+                    reward={reward}
+                    availablePoints={availablePoints}
+                    isAdmin={isAdmin}
+                    onEdit={handleEdit}
+                    onDelete={handleDelete}
+                    onRedeem={handleRedeem}
+                  />
+                ))}
+              </Box>
+            )}
+            {isAdmin && activeRewards.length > 0 && (
+              <Button
+                sx={{ mt: 2 }}
+                startDecorator={<Add />}
+                variant='soft'
+                onClick={handleAdd}
+              >
+                {t('view.createReward')}
+              </Button>
+            )}
+          </Box>
+        </TabPanel>
+
+        <TabPanel value='requests' sx={{ px: 0 }}>
+          <Box
+            sx={{
+              px: 2,
+              py: 2,
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 1.5,
+            }}
+          >
+            {(isAdmin ? pendingRedemptions : myRedemptions).length === 0 ? (
+              <EmptyState
+                fullHeight
+                icon={<Redeem />}
+                title={t('requests.emptyTitle')}
+                description={t('requests.emptyDescription')}
+              />
+            ) : (
+              (isAdmin ? pendingRedemptions : myRedemptions).map(redemption => (
+                <RedemptionRow
+                  key={redemption.id}
+                  redemption={redemption}
+                  isAdmin={isAdmin}
+                  onApprove={handleApprove}
+                  onReject={handleReject}
+                />
+              ))
+            )}
+          </Box>
+        </TabPanel>
+      </Tabs>
+
+      {modalOpen && (
+        <RewardModal
+          isOpen={modalOpen}
+          reward={currentReward}
+          onClose={() => {
+            setModalOpen(false)
+            invalidateAll()
+          }}
+        />
+      )}
+      <ConfirmationModal config={confirmationModel} />
+      <Box sx={getSafeBottomStyles({ bottom: 0, padding: 16 })} />
+    </Container>
+  )
+}
+
+export default RewardsView

--- a/src/views/components/NavBar.jsx
+++ b/src/views/components/NavBar.jsx
@@ -9,6 +9,7 @@ import {
   ListAlt,
   Logout,
   MenuRounded,
+  Redeem,
   ReportProblem,
   SearchRounded,
   SettingsOutlined,
@@ -94,6 +95,11 @@ const NavBar = () => {
       to: 'points',
       label: t('navigation.points'),
       icon: <Toll />,
+    },
+    {
+      to: 'rewards',
+      label: t('navigation.rewards'),
+      icon: <Redeem />,
     },
     {
       to: '/settings',


### PR DESCRIPTION
### What / why

Companion to [donetick/donetick#841](https://github.com/donetick/donetick/pull/841) — that PR adds the backend for a reward store (members spend points on admin-defined rewards, gated behind an approval step). This is the UI for it: a new `/rewards` page.

Also opened a [discussion](https://github.com/donetick/donetick/discussions/840) on the backend repo before sending these over, since I didn't find an existing issue for this — wanted to check it's something you'd actually want before it sits in review.

### What's there

- A store view: grid of active rewards, redeem button disabled if you're short on points (balance pulled from the same `useCircleMembers()` data `UserPoints.jsx` already uses)
- A requests tab: admins/managers see the pending queue and can approve/reject; everyone else sees their own redemption history
- Admin create/edit modal for managing the reward catalog
- Nav entry + route registered the same way Points/Labels are

### Approach

Tried to make this look like it was already part of the app rather than a new pattern:

- `RewardQueries.jsx` / `RewardsView.jsx` follow the same shape as `LabelQueries.jsx` / `LabelView.jsx` (react-query + offlineDB cache-on-success, IndexedDB fallback on failure)
- `RewardModal.jsx` is structurally copied from `LabelModal.jsx` — same validation-then-save-then-invalidate flow
- New Fetcher.jsx functions follow the existing method/header/body pattern used everywhere else in that file (alphabetized into the export list)
- Reused the already-imported-but-unused `Redeem` icon from `UserPoints.jsx` for the nav entry

### Testing

- `npm run build` clean
- `npx eslint --fix` clean (0 errors — the remaining warnings are the same `react/prop-types` pattern the rest of the codebase already has, e.g. `LabelModal.jsx`, not something new I introduced)
- Manually walked the flow against a locally-built instance of the backend PR: created a reward as admin, redeemed as a non-admin test account, approved it, confirmed the balance and pending queue update correctly

### Not in this PR

No search/sort/swipe-to-delete like the Labels list has — kept the store view simpler (a grid + edit/delete icon buttons) since I wasn't sure that level of interaction made sense for a smaller reward catalog. Easy to add if you'd rather match Labels' UX exactly.
